### PR TITLE
Big ass PR

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ gerber-types = "0.3.0"
 stringreader = "0.1.1"
 thiserror = "1.0.64"
 lazy-regex = "3.3.0"
+log = "0.4.22"
 
 [dev-dependencies]
 stringreader = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ regex = "1"
 gerber-types = "0.3.0"
 stringreader = "0.1.1"
 thiserror = "1.0.64"
+lazy-regex = "3.3.0"
 
 [dev-dependencies]
 stringreader = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ repository = "https://github.com/NemoAndrea/gerber-parser"
 regex = "1"
 gerber-types = "0.3.0"
 stringreader = "0.1.1"
+thiserror = "1.0.64"
 
 [dev-dependencies]
 stringreader = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/NemoAndrea/gerber-parser"
 
 [dependencies]
 regex = "1"
-gerber-types = "0.2.0"
+gerber-types = "0.3.0"
 stringreader = "0.1.1"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -26,18 +26,14 @@ let commands:Vec<Command> = gerber_doc.to_commands();
 Currently missing
 
 * All `AM` commands
-* `LM`, `LR`, `LS` commands (note: these are deprecated in the spec)
+* `LM`, `LR`, `LS`, `IP` commands (note: these are deprecated in the spec)
 * `AB` commands
 
 Partial:
 
 * The `TF` and `TA` commands only support a limited range of arguments; custom attributes will result in an error
 
-In addition, comments in the header section of the file (i.e. unit type declaration, format specification and aperture declarations) will be placed below the header when the parsed Gerber is converted back to string via serialisation. 
-
 ### General to-do
 
-* Make parsing a bit cleaner, with `Result`
-* Reduce the number of panics 
-* Make error messages clearer (avoid plain unwraps in places where errors can realistically occur)
 * Do proper coordinate check (compatibility with `format specification`)
+* Test with output from more programs (I use f360 and that seems to work)

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,45 @@
+use regex::Regex;
+use thiserror::Error;
+
+#[repr(u8)]
+#[derive(Error, Debug)]
+pub enum GerberParserError {
+    #[error("Document included a line that isn't valid: {0}")]
+    UnknownCommand(String),
+    #[error("Document included a line that isn't supported: {0}")]
+    UnsupportedCommand(String),
+    #[error("Missing M02 statement at end of file")]
+    NoEndOfFile,
+    #[error("Command was uniquely identified, but did not match regex: {0}, {1}")]
+    NoRegexMatch(String, Regex),
+    #[error("Command was uniquely identified, and matched expected regex, but did not contain the expected capture(s): {0}, {1}")]
+    MissingRegexCapture(String, Regex),
+    #[error("After gerber doc was already assigned a name, another name command was found. Line containing second name set: {0}")]
+    TriedToSetImageNameTwice(String),
+    #[error("After gerber doc was already assigned a unit, another unit command was found. Line containing second unit set: {0}")]
+    TriedToSetUnitsTwice(String),
+    #[error("After gerber doc was already assigned a format specification, another format specification command was found. Line containing second format specification set: {0}")]
+    TriedToFormatTwice(String),
+    #[error("Set unit command included unrecognized units: {0}")]
+    InvalidUnitFormat(String),
+    #[error("Error parsing format spec line. Looking for 2 digits but found 1 or none: {0}\nexpected something like \'%FSLAX23Y23*%\'")]
+    ParseFormatErrorWrongNumDigits(String),
+    #[error("format spec integer value must be between 1 and 6. Found {0}.")]
+    ParseFormatErrorInvalidDigit(u8),
+    #[error("Error parsing char as base 10 digit: {0}")]
+    ParseDigitError(char),
+    #[error("tried to parse \'{0}\' as an aperture code (integer) greater than 9 but failed")]
+    ApertureCodeParseFailed(String),
+    #[error("tried to parse the definition of aperture\'{0}\' but failed. Line: {1}")]
+    ParseApertureDefinitionBodyError(i32, String),
+    #[error("tried to parse the definition of aperture\'{0}\' but it already exists. Line: {1}")]
+    ApertureDefinedTwice(i32, String),
+    #[error("tried to parse the definition of aperture, but it uses an unknown type: {0}. Line: {1}")]
+    UnknownApertureType(String, String),
+    #[error("tried to parse the selection of aperture\'{0}\' but it is not defined. Line: {1}")]
+    ApertureNotDefined(i32, String),
+    #[error("tried to parse coordinate out of {0} but failed. This means a coordinate was captured, but could not be parsed as an i64")]
+    FailedToParseCoordinate(String),
+    #[error("Operation statement called before format specification. Line: {0}")]
+    OperationBeforeFormat(String),
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -99,6 +99,11 @@ pub enum GerberParserError {
     InvalidDeleteAttribute{
         delete_attribute: String,
     },
+    #[error("tried to parse a number in the drill tolerance aperture attribute, \
+    but found {number_str} which could not be parsed as an f64.")]
+    DrillToleranceParseNumError{
+        number_str: String,
+    }
 }
 
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,6 +50,20 @@ pub enum GerberParserError {
     UnsupportedPolarityType(String),
     #[error("The AttributeName '{0}' is currently not supported for File Attributes")]
     UnsupportedFileAttribute(String),
-    #[error("The Attribute '{0}' cannot be parsed")]
+    #[error("The File attribute '{0}' cannot be parsed")]
     InvalidFileAttribute(String),
+    #[error("The Aperture attribute '{0}' cannot be parsed or is mis-formed")]
+    InvalidApertureAttribute(String),
+    #[error("The Aperture attribute '{0}' is not supported, but presumably valid")]
+    UnsupportedApertureAttribute(String),
+    #[error("Failed to parse delete attribute '{0}'")]
+    InvalidDeleteAttribute(String),
+}
+
+
+impl PartialEq for GerberParserError {
+    /// Hack to simplify testing. Always returns false.
+    fn eq(&self, _: &Self) -> bool {
+        false
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,69 +1,122 @@
+use std::fmt::Formatter;
+use gerber_types::Aperture;
 use regex::Regex;
 use thiserror::Error;
 
-#[repr(u8)]
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum GerberParserError {
-    #[error("Document included a line that isn't valid: {0}")]
-    UnknownCommand(String),
-    #[error("Document included a line that isn't supported: {0}")]
-    UnsupportedCommand(String),
+    #[error("Document included a line that isn't valid.")]
+    UnknownCommand {},
+    #[error("Document included a line that isn't supported.")]
+    UnsupportedCommand{},
     #[error("Missing M02 statement at end of file")]
     NoEndOfFile,
-    #[error("Command was uniquely identified, but did not match regex: {0}, {1}")]
-    NoRegexMatch(String, Regex),
+    #[error("Command was uniquely identified, but did not match regex: {regex}.")]
+    NoRegexMatch{
+        regex: Regex,
+    },
     #[error("Command was uniquely identified, and matched expected regex, \
-    but did not contain the expected capture(s): {0}, {1}")]
-    MissingRegexCapture(String, Regex),
-    #[error("After gerber doc was already assigned a name, another name command was found. \
-    Line containing second name set: {0}")]
-    TriedToSetImageNameTwice(String),
-    #[error("After gerber doc was already assigned a unit, another unit command was found. \
-    Line containing second unit set: {0}")]
-    TriedToSetUnitsTwice(String),
+    but did not contain the expected capture(s).\nRegex: {regex}.")]
+    MissingRegexCapture{
+        regex: Regex,
+    },
+    #[error("After gerber doc was already assigned a name, another name command was found.")]
+    TriedToSetImageNameTwice{},
+    #[error("After gerber doc was already assigned a unit, another unit command was found.")]
+    TriedToSetUnitsTwice{},
     #[error("After gerber doc was already assigned a format specification, \
-    another format specification command was found. Line containing second format specification set: {0}")]
-    TriedToFormatTwice(String),
-    #[error("Set unit command included unrecognized units: {0}")]
-    InvalidUnitFormat(String),
-    #[error("Error parsing format spec line. Looking for 2 digits but found 1 or none: {0}\n
-    expected something like \'%FSLAX23Y23*%\'")]
-    ParseFormatErrorWrongNumDigits(String),
-    #[error("format spec integer value must be between 1 and 6. Found {0}.")]
-    ParseFormatErrorInvalidDigit(u8),
-    #[error("Error parsing char as base 10 digit: '{0}'")]
-    ParseDigitError(char),
-    #[error("tried to parse '{0}' as an aperture code (integer) greater than 9 but failed")]
-    ApertureCodeParseFailed(String),
-    #[error("tried to parse the definition of aperture '{0}' but failed. Line: {1}")]
-    ParseApertureDefinitionBodyError(i32, String),
-    #[error("tried to parse the definition of aperture '{0}' but it already exists. Line: {1}")]
-    ApertureDefinedTwice(i32, String),
-    #[error("tried to parse the definition of aperture, but it uses an unknown type: '{0}'. Line: {1}")]
-    UnknownApertureType(String, String),
-    #[error("tried to parse the selection of aperture '{0}' but it is not defined. Line: {1}")]
-    ApertureNotDefined(i32, String),
-    #[error("tried to parse coordinate out of '{0}' but failed. This means a coordinate was captured, \
-    but could not be parsed as an i64")]
-    FailedToParseCoordinate(String),
-    #[error("Operation statement called before format specification. Line: {0}")]
-    OperationBeforeFormat(String),
-    #[error("Unable to parse file attribute (TF). Line: {0}")]
-    FileAttributeParseError(String),
-    #[error("Unsupported Part type '{0}' in TF statement")]
-    UnsupportedPartType(String),
-    #[error("Unsupported Polarity type '{0}' in TF statement")]
-    UnsupportedPolarityType(String),
-    #[error("The AttributeName '{0}' is currently not supported for File Attributes")]
-    UnsupportedFileAttribute(String),
-    #[error("The File attribute '{0}' cannot be parsed")]
-    InvalidFileAttribute(String),
-    #[error("The Aperture attribute '{0}' cannot be parsed or is mis-formed")]
-    InvalidApertureAttribute(String),
-    #[error("The Aperture attribute '{0}' is not supported, but presumably valid")]
-    UnsupportedApertureAttribute(String),
-    #[error("Failed to parse delete attribute '{0}'")]
-    InvalidDeleteAttribute(String),
+    another format specification command was found.")]
+    TriedToFormatTwice{},
+    #[error("Set unit command included unrecognized units: {units_str}.")]
+    InvalidUnitFormat{
+        units_str: String,
+    },
+    #[error("Error parsing format spec line. Looking for 2 digits but found 1 or none.\n
+    expected something like \'%FSLAX23Y23*%\'.")]
+    ParseFormatErrorWrongNumDigits{},
+    #[error("format spec integer value must be between 1 and 6. Found {digit_found}.")]
+    ParseFormatErrorInvalidDigit{
+        digit_found: u8,
+    },
+    #[error("Error parsing char as base 10 digit: '{char_found:?}'.")]
+    ParseDigitError{
+        char_found: char,
+    },
+    #[error("tried to parse '{aperture_code_str}' as an aperture code (integer) greater than 9 but failed.")]
+    ApertureCodeParseFailed{
+        aperture_code_str: String,
+    },
+    #[error("tried to parse the definition of aperture '{aperture_code}' but failed.")]
+    ParseApertureDefinitionBodyError{
+        aperture_code: i32,
+    },
+    #[error("tried to parse the definition of aperture '{aperture_code}' but it already exists.")]
+    ApertureDefinedTwice{
+        aperture_code: i32,
+    },
+    #[error("tried to parse the definition of aperture, but it uses an unknown type: '{type_str}'.")]
+    UnknownApertureType{
+        type_str: String,
+    },
+    #[error("tried to parse the selection of aperture '{aperture_code}' but it is not defined.")]
+    ApertureNotDefined{
+        aperture_code: i32,
+    },
+    #[error("tried to parse coordinate number out of '{coord_num_str}' but failed. \
+    This means a coordinate was captured, but could not be parsed as an i64.")]
+    FailedToParseCoordinate{
+        coord_num_str: String,
+    },
+    #[error("Operation statement called before format specification.")]
+    OperationBeforeFormat{},
+    #[error("Unable to parse file attribute (TF).")]
+    FileAttributeParseError{},
+    #[error("Unsupported Part type '{part_type}' in TF statement.")]
+    UnsupportedPartType{
+        part_type: String,
+    },
+    #[error("Unsupported Polarity type '{polarity_type}' in TF statement.")]
+    UnsupportedPolarityType{
+        polarity_type: String,
+    },
+    #[error("The AttributeName '{attribute_name}' is currently not supported for File Attributes.")]
+    UnsupportedFileAttribute{
+        attribute_name: String,
+    },
+    #[error("The File attribute '{file_attribute}' cannot be parsed.")]
+    InvalidFileAttribute{
+        file_attribute: String,
+    },
+    #[error("The Aperture attribute '{aperture_attribute}' cannot be parsed or is mis-formed.")]
+    InvalidApertureAttribute{
+        aperture_attribute: String,
+    },
+    #[error("The Aperture attribute '{aperture_attribute}' is not supported, but presumably valid.")]
+    UnsupportedApertureAttribute{
+        aperture_attribute: String,
+    },
+    #[error("Failed to parse delete attribute '{delete_attribute}'.")]
+    InvalidDeleteAttribute{
+        delete_attribute: String,
+    },
+}
+
+
+impl GerberParserError{
+    pub fn to_with_context(self, line: Option<String>, line_num: Option<usize>) -> GerberParserErrorWithContext{
+        GerberParserErrorWithContext{
+            error: self,
+            line,
+            line_num,
+        }
+    }
+    pub fn as_with_context(&self, line: Option<String>, line_num: Option<usize>) -> GerberParserErrorWithContext{
+        GerberParserErrorWithContext{
+            error: self.clone(),
+            line,
+            line_num,
+        }
+    }
 }
 
 
@@ -71,5 +124,25 @@ impl PartialEq for GerberParserError {
     /// Hack to simplify testing. Always returns false.
     fn eq(&self, _: &Self) -> bool {
         false
+    }
+}
+
+#[derive(Error, Debug, PartialEq)]
+pub struct GerberParserErrorWithContext {
+    error: GerberParserError,
+    line: Option<String>,
+    line_num: Option<usize>,
+}
+
+impl std::fmt::Display for GerberParserErrorWithContext {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match (&self.line, &self.line_num) {
+            (Some(line), Some(line_num)) => {
+                write!(f, "Error: {}\nLine: '{}: {}'", self.error, line_num, line)
+            }
+            _ => {
+                write!(f, "Error at unspecified line: {}", self.error)
+            }
+        }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,20 +26,30 @@ pub enum GerberParserError {
     ParseFormatErrorWrongNumDigits(String),
     #[error("format spec integer value must be between 1 and 6. Found {0}.")]
     ParseFormatErrorInvalidDigit(u8),
-    #[error("Error parsing char as base 10 digit: {0}")]
+    #[error("Error parsing char as base 10 digit: '{0}'")]
     ParseDigitError(char),
-    #[error("tried to parse \'{0}\' as an aperture code (integer) greater than 9 but failed")]
+    #[error("tried to parse '{0}' as an aperture code (integer) greater than 9 but failed")]
     ApertureCodeParseFailed(String),
-    #[error("tried to parse the definition of aperture\'{0}\' but failed. Line: {1}")]
+    #[error("tried to parse the definition of aperture '{0}' but failed. Line: {1}")]
     ParseApertureDefinitionBodyError(i32, String),
-    #[error("tried to parse the definition of aperture\'{0}\' but it already exists. Line: {1}")]
+    #[error("tried to parse the definition of aperture '{0}' but it already exists. Line: {1}")]
     ApertureDefinedTwice(i32, String),
-    #[error("tried to parse the definition of aperture, but it uses an unknown type: {0}. Line: {1}")]
+    #[error("tried to parse the definition of aperture, but it uses an unknown type: '{0}'. Line: {1}")]
     UnknownApertureType(String, String),
-    #[error("tried to parse the selection of aperture\'{0}\' but it is not defined. Line: {1}")]
+    #[error("tried to parse the selection of aperture '{0}' but it is not defined. Line: {1}")]
     ApertureNotDefined(i32, String),
-    #[error("tried to parse coordinate out of {0} but failed. This means a coordinate was captured, but could not be parsed as an i64")]
+    #[error("tried to parse coordinate out of '{0}' but failed. This means a coordinate was captured, but could not be parsed as an i64")]
     FailedToParseCoordinate(String),
     #[error("Operation statement called before format specification. Line: {0}")]
     OperationBeforeFormat(String),
+    #[error("Unable to parse file attribute (TF). Line: {0}")]
+    FileAttributeParseError(String),
+    #[error("Unsupported Part type '{0}' in TF statement")]
+    UnsupportedPartType(String),
+    #[error("Unsupported Polarity type '{0}' in TF statement")]
+    UnsupportedPolarityType(String),
+    #[error("The AttributeName '{0}' is currently not supported for File Attributes")]
+    UnsupportedFileAttribute(String),
+    #[error("The Attribute '{0}' cannot be parsed")]
+    InvalidFileAttribute(String),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,17 +12,22 @@ pub enum GerberParserError {
     NoEndOfFile,
     #[error("Command was uniquely identified, but did not match regex: {0}, {1}")]
     NoRegexMatch(String, Regex),
-    #[error("Command was uniquely identified, and matched expected regex, but did not contain the expected capture(s): {0}, {1}")]
+    #[error("Command was uniquely identified, and matched expected regex, \
+    but did not contain the expected capture(s): {0}, {1}")]
     MissingRegexCapture(String, Regex),
-    #[error("After gerber doc was already assigned a name, another name command was found. Line containing second name set: {0}")]
+    #[error("After gerber doc was already assigned a name, another name command was found. \
+    Line containing second name set: {0}")]
     TriedToSetImageNameTwice(String),
-    #[error("After gerber doc was already assigned a unit, another unit command was found. Line containing second unit set: {0}")]
+    #[error("After gerber doc was already assigned a unit, another unit command was found. \
+    Line containing second unit set: {0}")]
     TriedToSetUnitsTwice(String),
-    #[error("After gerber doc was already assigned a format specification, another format specification command was found. Line containing second format specification set: {0}")]
+    #[error("After gerber doc was already assigned a format specification, \
+    another format specification command was found. Line containing second format specification set: {0}")]
     TriedToFormatTwice(String),
     #[error("Set unit command included unrecognized units: {0}")]
     InvalidUnitFormat(String),
-    #[error("Error parsing format spec line. Looking for 2 digits but found 1 or none: {0}\nexpected something like \'%FSLAX23Y23*%\'")]
+    #[error("Error parsing format spec line. Looking for 2 digits but found 1 or none: {0}\n
+    expected something like \'%FSLAX23Y23*%\'")]
     ParseFormatErrorWrongNumDigits(String),
     #[error("format spec integer value must be between 1 and 6. Found {0}.")]
     ParseFormatErrorInvalidDigit(u8),
@@ -38,7 +43,8 @@ pub enum GerberParserError {
     UnknownApertureType(String, String),
     #[error("tried to parse the selection of aperture '{0}' but it is not defined. Line: {1}")]
     ApertureNotDefined(i32, String),
-    #[error("tried to parse coordinate out of '{0}' but failed. This means a coordinate was captured, but could not be parsed as an i64")]
+    #[error("tried to parse coordinate out of '{0}' but failed. This means a coordinate was captured, \
+    but could not be parsed as an i64")]
     FailedToParseCoordinate(String),
     #[error("Operation statement called before format specification. Line: {0}")]
     OperationBeforeFormat(String),

--- a/src/gerber_doc.rs
+++ b/src/gerber_doc.rs
@@ -74,17 +74,24 @@ impl GerberDoc {
 
 impl fmt::Display for GerberDoc {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let int_str: String = repeat("_")
-            .take(self.format_specification.unwrap().integer as usize).collect();
-        let dec_str: String = repeat("_")
-            .take(self.format_specification.unwrap().decimal as usize).collect();
         writeln!(f, "GerberDoc")?;
         writeln!(f, "- units: {:?}", self.units)?;
-        writeln!(f, "- format spec: {}.{} ({}|{})", 
-                 int_str, 
-                 dec_str, 
-                 self.format_specification.unwrap().integer, 
-                 self.format_specification.unwrap().decimal)?;
+        match self.format_specification{
+            None => {
+                writeln!(f, "- no format spec!")?;
+            }
+            Some(format_spec) => {
+                let int_str: String = repeat("_").take(format_spec.integer as usize).collect();
+                let dec_str: String = repeat("_").take(format_spec.decimal as usize).collect();
+                writeln!(f, "- format spec: {}.{} ({}|{})",
+                         int_str,
+                         dec_str,
+                         format_spec.integer,
+                         format_spec.decimal
+                )?;
+            }
+        }
+        
         writeln!(f, "- apertures: ")?;
         for (code, _) in &self.apertures {
             writeln!(f, "\t {}", code)?;

--- a/src/gerber_doc.rs
+++ b/src/gerber_doc.rs
@@ -13,8 +13,10 @@ pub struct GerberDoc {
     pub format_specification: Option<CoordinateFormat>,
     /// map of apertures which can be used in draw commands later on in the document. 
     pub apertures: HashMap::<i32, Aperture>,
-    // Anything else, draw commands, comments, attributes 
-    pub commands: Vec<Command>    
+    // Anything else, draw commands, comments, attributes
+    pub commands: Vec<Command>,
+    /// Image Name, 8.1.3. Deprecated, but still used by fusion 360.
+    pub image_name: Option<String>
 }
 
 impl GerberDoc {
@@ -24,7 +26,8 @@ impl GerberDoc {
             units: None,
             format_specification: None,
             apertures: HashMap::new(),
-            commands: Vec::new()
+            commands: Vec::new(),
+            image_name: None,
         }
     }
 

--- a/src/gerber_doc.rs
+++ b/src/gerber_doc.rs
@@ -37,6 +37,8 @@ impl GerberDoc {
     /// in the gerber-types rust crate. Note that aperture definitions will be sorted by code number
     /// with lower codes being at the top of the command. This is independent of their order during
     /// parsing.
+    /// 
+    /// This will ignore any errors encountered during parsing, to access those use `get_errors`
     pub fn to_commands(self) -> Vec<Command> {
         let mut gerber_cmds: Vec<Command> = Vec::new();
         match self.format_specification{
@@ -90,11 +92,17 @@ impl GerberDoc {
 
 impl fmt::Display for GerberDoc {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let int_str: String = repeat("_").take(self.format_specification.unwrap().integer as usize).collect();
-        let dec_str: String = repeat("_").take(self.format_specification.unwrap().decimal as usize).collect();
+        let int_str: String = repeat("_")
+            .take(self.format_specification.unwrap().integer as usize).collect();
+        let dec_str: String = repeat("_")
+            .take(self.format_specification.unwrap().decimal as usize).collect();
         writeln!(f, "GerberDoc")?;
         writeln!(f, "- units: {:?}", self.units)?;
-        writeln!(f, "- format spec: {}.{} ({}|{})", int_str, dec_str, self.format_specification.unwrap().integer, self.format_specification.unwrap().decimal)?;
+        writeln!(f, "- format spec: {}.{} ({}|{})", 
+                 int_str, 
+                 dec_str, 
+                 self.format_specification.unwrap().integer, 
+                 self.format_specification.unwrap().decimal)?;
         writeln!(f, "- apertures: ")?;
         for (code, _) in &self.apertures {
             writeln!(f, "\t {}", code)?;

--- a/src/gerber_doc.rs
+++ b/src/gerber_doc.rs
@@ -2,9 +2,9 @@ use gerber_types::{Unit, CoordinateFormat, Aperture, Command, ExtendedCode, Aper
 use::std::collections::HashMap;
 use std::fmt;
 use std::iter::repeat;
+use crate::error::GerberParserError;
 
-
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 // Representation of Gerber document 
 pub struct GerberDoc {
     // unit type, defined once per document
@@ -14,7 +14,7 @@ pub struct GerberDoc {
     /// map of apertures which can be used in draw commands later on in the document. 
     pub apertures: HashMap::<i32, Aperture>,
     // Anything else, draw commands, comments, attributes
-    pub commands: Vec<Command>,
+    pub commands: Vec<Result<Command, GerberParserError>>,
     /// Image Name, 8.1.3. Deprecated, but still used by fusion 360.
     pub image_name: Option<String>
 }
@@ -37,20 +37,21 @@ impl GerberDoc {
     /// in the gerber-types rust crate. Note that aperture definitions will be sorted by code number
     /// with lower codes being at the top of the command. This is independent of their order during
     /// parsing.
-    pub fn to_commands(mut self) -> Vec<Command> {
-        let mut gerber_cmds: Vec<Command> = Vec::new();
-        gerber_cmds.push(ExtendedCode::CoordinateFormat(self.format_specification.unwrap()).into());
-        gerber_cmds.push(ExtendedCode::Unit(self.units.unwrap()).into());
+    pub fn to_commands(mut self) -> Vec<Result<Command, GerberParserError>> {
+        let mut gerber_cmds: Vec<Result<Command, GerberParserError>> = Vec::new();
+        gerber_cmds.push(Ok(ExtendedCode::CoordinateFormat(self.format_specification.unwrap()).into()));
+        gerber_cmds.push(Ok(ExtendedCode::Unit(self.units.unwrap()).into()));
 
         // we add the apertures to the list, but we sort by code. This means the order of the output
         // is reproducible every time. 
         let mut apertures = self.apertures.into_iter().collect::<Vec<_>>();
         apertures.sort_by_key(|tup| tup.0);
         for (code, aperture) in apertures {
-            gerber_cmds.push(ExtendedCode::ApertureDefinition(ApertureDefinition {
-                code: code,
-                aperture: aperture}).into())
-        }        
+            gerber_cmds.push(Ok(ExtendedCode::ApertureDefinition(ApertureDefinition {
+                code,
+                aperture,
+            }).into()));
+        }
 
         gerber_cmds.append(&mut self.commands);
         // TODO implement for units        
@@ -62,12 +63,12 @@ impl fmt::Display for GerberDoc {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let int_str: String = repeat("_").take(self.format_specification.unwrap().integer as usize).collect();
         let dec_str: String = repeat("_").take(self.format_specification.unwrap().decimal as usize).collect();
-        writeln!(f, "GerberDoc").unwrap();
-        writeln!(f, "- units: {:?}", self.units).unwrap();
-        writeln!(f, "- format spec: {}.{} ({}|{})", int_str, dec_str, self.format_specification.unwrap().integer, self.format_specification.unwrap().decimal).unwrap();
-        writeln!(f, "- apertures: ").unwrap();
+        writeln!(f, "GerberDoc")?;
+        writeln!(f, "- units: {:?}", self.units)?;
+        writeln!(f, "- format spec: {}.{} ({}|{})", int_str, dec_str, self.format_specification.unwrap().integer, self.format_specification.unwrap().decimal)?;
+        writeln!(f, "- apertures: ")?;
         for (code, _) in &self.apertures {
-            writeln!(f, "\t {}", code).unwrap();
+            writeln!(f, "\t {}", code)?;
         }
         write!(f, "- commands: {}", &self.commands.len())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,4 +14,4 @@
 
 pub mod parser;
 pub mod gerber_doc;
-mod error;
+pub mod error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,3 +14,4 @@
 
 pub mod parser;
 pub mod gerber_doc;
+mod error;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3,7 +3,7 @@ use gerber_types::{Command, ExtendedCode, Unit, FunctionCode, GCode, CoordinateF
      Aperture, Circle, Rectangular, Polygon, MCode, DCode, Polarity,
       InterpolationMode, QuadrantMode, Operation, Coordinates, CoordinateNumber, CoordinateOffset,
        ApertureAttribute, ApertureFunction, FiducialScope, SmdPadType, FileAttribute, FilePolarity,
-        Part, FileFunction, ObjectAttribute, StepAndRepeat};
+        Part, FileFunction, StepAndRepeat};
 use regex::Regex;
 use std::str::Chars;
 use crate::gerber_doc::{ GerberDoc};
@@ -78,7 +78,7 @@ pub fn parse_gerber<T: Read>(reader: BufReader<T>) -> GerberDoc {
                         'F' => { parse_format_spec(line, &re_formatspec, &mut gerber_doc) },
                         'A' => match linechars.next().unwrap() {
                             'D' => { parse_aperture_defs(line, &re_aperture, &mut gerber_doc) }, // AD
-                            'M' => { panic!("Aperture Macros (AM) are not supported yet.") }, // AM 
+                            'M' => { println!("Aperture Macros (AM) are not supported yet.") }, // AM
                             _ => line_parse_failure(line, index)
                         }, 
                         'L' => match linechars.next().unwrap() {
@@ -95,7 +95,6 @@ pub fn parse_gerber<T: Read>(reader: BufReader<T>) -> GerberDoc {
                         'T' => match linechars.next().unwrap() {
                             'F' => { parse_file_attribute(linechars, &re_attributes,  &mut gerber_doc) },
                             'A' => { parse_aperture_attribute(linechars, &re_attributes, &mut gerber_doc) },
-                            'O' => { parse_object_attribute(linechars, &re_attributes, &mut gerber_doc) },
                             'D' => { parse_delete_attribute(linechars, &re_attributes, &mut gerber_doc) },
                             _ => line_parse_failure(line, index)
                         },
@@ -142,7 +141,7 @@ pub fn parse_gerber<T: Read>(reader: BufReader<T>) -> GerberDoc {
 
 // print a simple message in case the parser hits a dead end
 fn line_parse_failure(line: &str, index: usize) {
-    panic!("Cannot parse line:\n{} | {}", index, line)
+    println!("Cannot parse line:\n{} | {}", index, line)
 } 
 
 
@@ -488,23 +487,6 @@ fn parse_aperture_attribute(line: Chars, re: &Regex, gerber_doc: &mut GerberDoc)
         }        
     }
     else { panic!("Unable to parse aperture attribute (TA)" )} 
-}
-
-
-fn parse_object_attribute(line: Chars, re: &Regex, gerber_doc: &mut GerberDoc) {
-    let attr_args = get_attr_args(line);
-    if attr_args.len() >= 2 {
-        gerber_doc.commands.push(
-            ExtendedCode::ObjectAttribute(ObjectAttribute{
-                attribute_name: attr_args[0].to_string(),
-                values: attr_args[1..].into_iter().map(|val| val.to_string()).collect()
-            }).into()
-        )
-    } else if attr_args.len() == 1 {
-        panic!("Unable to add Object Attribute (TO) - TO statements need at least 1 field value on top of the name: '{}'", attr_args[0]);
-    } else {
-         panic!("Unable to parse object attribute (TO)");
-    }
 }
 
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,17 +1,20 @@
 use std::{io::{Read, BufReader, BufRead}, fs::File};
+use std::num::ParseIntError;
 use gerber_types::{Command, ExtendedCode, Unit, FunctionCode, GCode, CoordinateFormat,
-     Aperture, Circle, Rectangular, Polygon, MCode, DCode, Polarity,
-      InterpolationMode, QuadrantMode, Operation, Coordinates, CoordinateNumber, CoordinateOffset,
-       ApertureAttribute, ApertureFunction, FiducialScope, SmdPadType, FileAttribute, FilePolarity,
-        Part, FileFunction, StepAndRepeat};
-use regex::Regex;
+                   Aperture, Circle, Rectangular, Polygon, MCode, DCode, Polarity,
+                   InterpolationMode, QuadrantMode, Operation, Coordinates, CoordinateNumber, CoordinateOffset,
+                   ApertureAttribute, ApertureFunction, FiducialScope, SmdPadType, FileAttribute, FilePolarity,
+                   Part, FileFunction, StepAndRepeat};
+use regex::{Captures, Regex};
 use std::str::Chars;
+use crate::error::GerberParserError;
+use crate::error::GerberParserError::TriedToFormatTwice;
 use crate::gerber_doc::{ GerberDoc};
 
 /// Parse a gerber string (in BufReader) to a GerberDoc
 /// 
 /// Take the contents of a Gerber (.gbr) file and parse it to a GerberDoc struct. The parsing does
-/// some semantic checking, but is is certainly not exhaustive - so don't rely on it to check if
+/// some semantic checking, but is certainly not exhaustive - so don't rely on it to check if
 /// your Gerber file is valid according to the spec. Some of the parsing steps are greedy - they may
 /// match something unexpected (rather than panicking) if there is a typo/fault in your file.
 pub fn parse_gerber<T: Read>(reader: BufReader<T>) -> GerberDoc {
@@ -36,9 +39,9 @@ pub fn parse_gerber<T: Read>(reader: BufReader<T>) -> GerberDoc {
     let re_step_repeat = Regex::new(r"%SRX([0-9]+)Y([0-9]+)I(\d+\.?\d*)J(\d+\.?\d*)\*%").unwrap();  
 
     for (index, line) in reader.lines().enumerate() {
-        let rawline = line.unwrap(); 
+        let raw_line = line.expect("IO Error reading line"); 
         // TODO combine this with line above
-        let line = rawline.trim();
+        let line = raw_line.trim();
 
         // Show the line 
         //println!("{}. {}", index + 1, &line);
@@ -49,300 +52,383 @@ pub fn parse_gerber<T: Read>(reader: BufReader<T>) -> GerberDoc {
                 'G' => {
                     match linechars.next().unwrap() {
                         '0' =>  match linechars.next().unwrap() {
-                            '1' => gerber_doc.commands.push(FunctionCode::GCode(
-                                GCode::InterpolationMode(InterpolationMode::Linear)).into()), // G01
-                            '2' => gerber_doc.commands.push(FunctionCode::GCode(
-                                GCode::InterpolationMode(InterpolationMode::ClockwiseCircular)).into()), // G02
-                            '3' => gerber_doc.commands.push(FunctionCode::GCode(
-                                GCode::InterpolationMode(InterpolationMode::CounterclockwiseCircular)).into()), // G03
-                            '4' => {parse_comment(line, &re_comment, &mut gerber_doc) }, // G04
-                            _ => line_parse_failure(line, index),
+                            '1' => gerber_doc.commands.push(Ok(FunctionCode::GCode(
+                                GCode::InterpolationMode(InterpolationMode::Linear)).into())), // G01
+                            '2' => gerber_doc.commands.push(Ok(FunctionCode::GCode(
+                                GCode::InterpolationMode(InterpolationMode::ClockwiseCircular)).into())), // G02
+                            '3' => gerber_doc.commands.push(Ok(FunctionCode::GCode(
+                                GCode::InterpolationMode(InterpolationMode::CounterclockwiseCircular)).into())), // G03
+                            '4' => {gerber_doc.commands.push(parse_comment(line, &re_comment)) }, // G04
+                            _ => gerber_doc.commands.push(Err(GerberParserError::UnknownCommand(line.to_string()))),
                         },
                         '3'=> match linechars.next().unwrap() {
-                            '6' => gerber_doc.commands.push(FunctionCode::GCode(GCode::RegionMode(true)).into()), // G36
-                            '7' => gerber_doc.commands.push(FunctionCode::GCode(GCode::RegionMode(false)).into()), // G37
-                            _ => line_parse_failure(line, index),
+                            '6' => gerber_doc.commands.push(Ok(FunctionCode::GCode(GCode::RegionMode(true)).into())), // G36
+                            '7' => gerber_doc.commands.push(Ok(FunctionCode::GCode(GCode::RegionMode(false)).into())), // G37
+                            _ => gerber_doc.commands.push(Err(GerberParserError::UnknownCommand(line.to_string()))),
                         },
                         '7' => match linechars.next().unwrap() {
                             // the G74 command is technically part of the Deprecated commands
-                            '4' => gerber_doc.commands.push(FunctionCode::GCode(GCode::QuadrantMode(QuadrantMode::Single)).into()), // G74
-                            '5' => gerber_doc.commands.push(FunctionCode::GCode(GCode::QuadrantMode(QuadrantMode::Multi)).into()), // G74
-                            _ => line_parse_failure(line, index),
+                            '4' => gerber_doc.commands.push(Ok(FunctionCode::GCode(GCode::QuadrantMode(QuadrantMode::Single)).into())), // G74
+                            '5' => gerber_doc.commands.push(Ok(FunctionCode::GCode(GCode::QuadrantMode(QuadrantMode::Multi)).into())), // G74
+                            _ => gerber_doc.commands.push(Err(GerberParserError::UnknownCommand(line.to_string()))),
                         }, // G75
-                        _ => line_parse_failure(line, index),             
+                        _ => gerber_doc.commands.push(Err(GerberParserError::UnknownCommand(line.to_string()))),
                     }
                 },
                 '%' => {
                     match linechars.next().unwrap() {
-                        'M' => { parse_units(line, &re_units, &mut gerber_doc) },
-                        'F' => { parse_format_spec(line, &re_formatspec, &mut gerber_doc) },
+                        'M' => { 
+                            match parse_units(line, &re_units, &gerber_doc){
+                                Ok(units) => {
+                                    gerber_doc.units = Some(units);
+                                }
+                                Err(e) => {
+                                    gerber_doc.commands.push(Err(e));
+                                }
+                            }
+                        },
+                        'F' => { 
+                            match parse_format_spec(line, &re_units, &gerber_doc){
+                                Ok(format_spec) => {
+                                    gerber_doc.format_specification = Some(format_spec);
+                                }
+                                Err(e) => {
+                                    gerber_doc.commands.push(Err(e));
+                                }
+                            } 
+                        },
                         'A' => match linechars.next().unwrap() {
-                            'D' => { parse_aperture_defs(line, &re_aperture, &mut gerber_doc) }, // AD
-                            'M' => { println!("Aperture Macros (AM) are not supported yet.") }, // AM
-                            _ => line_parse_failure(line, index)
+                            'D' => { 
+                                match parse_aperture_defs(line, &re_aperture, &gerber_doc){
+                                    Ok((code, ap)) => {
+                                        gerber_doc.apertures.insert(code, ap); 
+                                        // Safety: While insert can 'fail' (misbehave) if the key 
+                                        // already exists, 
+                                        // `parse_aperture_defs` explicitly checks for this
+                                    }
+                                    Err(err) => {
+                                        gerber_doc.commands.push(Err(err));
+                                    }
+                                } 
+                            }, // AD
+                            'M' => { gerber_doc.commands.push(Err(GerberParserError::UnsupportedCommand(line.to_string()))) }, // AM
+                            _ => gerber_doc.commands.push(Err(GerberParserError::UnknownCommand(line.to_string())))
                         }, 
                         'L' => match linechars.next().unwrap() {
                             'P' => match linechars.next().unwrap() {
-                                'D' => gerber_doc.commands.push(ExtendedCode::LoadPolarity(Polarity::Dark).into()), // LPD
-                                'C' => gerber_doc.commands.push(ExtendedCode::LoadPolarity(Polarity::Clear).into()), // LPC
-                                _ => line_parse_failure(line, index)
+                                'D' => gerber_doc.commands.push(Ok(ExtendedCode::LoadPolarity(Polarity::Dark).into())), // LPD
+                                'C' => gerber_doc.commands.push(Ok(ExtendedCode::LoadPolarity(Polarity::Clear).into())), // LPC
+                                _ => gerber_doc.commands.push(Err(GerberParserError::UnknownCommand(line.to_string())))
                             }, // LP
-                            'M' => parse_load_mirroring(linechars, &mut gerber_doc), // LM 
-                            'R' => { panic!("Load Mirroring (LM) command not supported yet.") }, // LR
-                            'S' => { panic!("Load Scaling (LS) command not supported yet.") }, // LS
-                            _ => line_parse_failure(line, index)
+                            'M' => { gerber_doc.commands.push(Err(GerberParserError::UnsupportedCommand(line.to_string()))) }, // LM 
+                            'R' => { gerber_doc.commands.push(Err(GerberParserError::UnsupportedCommand(line.to_string()))) }, // LR
+                            'S' => { gerber_doc.commands.push(Err(GerberParserError::UnsupportedCommand(line.to_string()))) }, // LS
+                            _ => gerber_doc.commands.push(Err(GerberParserError::UnknownCommand(line.to_string())))
                         },
                         'T' => match linechars.next().unwrap() {
                             'F' => { parse_file_attribute(linechars, &re_attributes,  &mut gerber_doc) },
                             'A' => { parse_aperture_attribute(linechars, &re_attributes, &mut gerber_doc) },
                             'D' => { parse_delete_attribute(linechars, &re_attributes, &mut gerber_doc) },
-                            _ => line_parse_failure(line, index)
+                            _ => gerber_doc.commands.push(Err(GerberParserError::UnknownCommand(line.to_string())))
                         },
                         'S' => match linechars.next().unwrap() { 
                             'R' => match linechars.next().unwrap() {
-                                'X' => parse_step_repeat_open(line, &re_step_repeat, &mut gerber_doc),
+                                'X' => gerber_doc.commands.push(parse_step_repeat_open(line, &re_step_repeat, &gerber_doc)),
                                 // a statement %SR*% closes a step repeat command, which has no parameters
-                                '*' => gerber_doc.commands.push(ExtendedCode::StepAndRepeat(StepAndRepeat::Close).into()),
-                                _ => line_parse_failure(line, index)
+                                '*' => gerber_doc.commands.push(Ok(ExtendedCode::StepAndRepeat(StepAndRepeat::Close).into())),
+                                _ => gerber_doc.commands.push(Err(GerberParserError::UnknownCommand(line.to_string())))
                             },
-                            _ => line_parse_failure(line, index),                            
+                            _ => gerber_doc.commands.push(Err(GerberParserError::UnknownCommand(line.to_string())))                          
                         },
                         'I' => match linechars.next().unwrap() {
-                            'N' => { parse_image_name(line, &re_image_name, &mut gerber_doc) }, // Image Name, 8.1.3. Deprecated, but still used by fusion 360.
-                            'P' => { parse_image_polarity(line, &re_image_polarity, &mut gerber_doc) }, // Image Polarity, basically useless, but used by fusion
-                            _ => line_parse_failure(line, index)
+                            'N' => { // Image Name, 8.1.3. Deprecated, but still used by fusion 360.
+                                match parse_image_name(line, &re_image_name, &gerber_doc) {
+                                    Ok(name) => {
+                                        gerber_doc.image_name = Some(name);
+                                    }
+                                    Err(e) => {
+                                        gerber_doc.commands.push(Err(e))
+                                    }
+                                }
+                            }, 
+                            'P' => { gerber_doc.commands.push(Err(GerberParserError::UnsupportedCommand(line.to_string()))) }, // Image Polarity, basically useless, but used by fusion
+                            _ => gerber_doc.commands.push(Err(GerberParserError::UnknownCommand(line.to_string())))
                         }
-                        _ => line_parse_failure(line, index)
+                        _ => gerber_doc.commands.push(Err(GerberParserError::UnknownCommand(line.to_string())))
                     }
                 },
                 'X' | 'Y' => {linechars.next_back(); match linechars.next_back().unwrap() { 
-                    '1' => parse_interpolation(line, &re_interpolation,&mut gerber_doc, &mut last_coords), // D01
-                    '2' => parse_move_or_flash(line, &re_move_or_flash,&mut gerber_doc, &mut last_coords, false), // D02
-                    '3' => parse_move_or_flash(line, &re_move_or_flash,&mut gerber_doc, &mut last_coords, true), // D03
-                    _ => line_parse_failure(line, index)
+                    '1' => gerber_doc.commands.push(parse_interpolation(line, &re_interpolation, &gerber_doc, &mut last_coords)), // D01
+                    '2' => gerber_doc.commands.push(parse_move_or_flash(line, &re_move_or_flash,&gerber_doc, &mut last_coords, false)), // D02
+                    '3' => gerber_doc.commands.push(parse_move_or_flash(line, &re_move_or_flash,&gerber_doc, &mut last_coords, true)), // D03
+                    _ => gerber_doc.commands.push(Err(GerberParserError::UnknownCommand(line.to_string())))
                 }},
                 'D' => { // select aperture D<num>*                   
                     linechars.next_back(); // remove the trailing '*'
-                    parse_aperture_selection(linechars, &mut gerber_doc)
+                    gerber_doc.commands.push(parse_aperture_selection(linechars, &gerber_doc))
                 },                
-                'M' => { gerber_doc.commands.push(FunctionCode::MCode(MCode::EndOfFile).into())}                
-                _ => line_parse_failure(line, index)
+                'M' => { gerber_doc.commands.push(Ok(FunctionCode::MCode(MCode::EndOfFile).into())) }                
+                _ => gerber_doc.commands.push(Err(GerberParserError::UnknownCommand(line.to_string())))
             }           
         }
     }
 
-    // check that we ended with a gerber EOF command
-    assert_eq!(gerber_doc.commands.last().unwrap(), &Command::FunctionCode(FunctionCode::MCode(MCode::EndOfFile)),
-        "Missing M02 statement at end of file");
+    // TODO: check that we ended with a gerber EOF command
 
     return gerber_doc
 }
 
 
-// print a simple message in case the parser hits a dead end
-fn line_parse_failure(line: &str, index: usize) {
-    println!("Cannot parse line:\n{} | {}", index, line)
-} 
-
-
-// parse a Gerber Comment (e.g. 'G04 This is a comment*')
-fn parse_comment(line: &str, re: &Regex, gerber_doc: &mut GerberDoc) {
-    if let Some(regmatch) = re.captures(line) {
-        let comment = regmatch.get(1).unwrap().as_str();
-        gerber_doc.commands.push(FunctionCode::GCode(GCode::Comment(comment.to_string())).into());
-    } 
+/// parse a Gerber Comment (e.g. 'G04 This is a comment*')
+fn parse_comment(line: &str, re: &Regex) -> Result<Command, GerberParserError> {
+    match re.captures(line) {
+        Some(regmatch) => {
+            let comment = regmatch.get(1).ok_or(GerberParserError::MissingRegexCapture(line.to_string(), re.clone()))?.as_str();
+            Ok(FunctionCode::GCode(GCode::Comment(comment.to_string())).into())
+        }
+        None => { Err(GerberParserError::NoRegexMatch(line.to_string(), re.clone())) }
+    }
+    
 }
 
 /// parse an image name. This is optional and deprecated, but included in all exports from Fusion 360
-fn parse_image_name(line: &str, re: &Regex, gerber_doc: &mut GerberDoc) {
-    if gerber_doc.image_name != None { panic!{"Cannot set image name twice in the same document!"} }
-    if let Some(regmatch) = re.captures(line) {
-        let comment = regmatch.get(1).unwrap().as_str();
-        gerber_doc.image_name = Some(String::from(comment))
+fn parse_image_name(line: &str, re: &Regex, gerber_doc: &GerberDoc) -> Result<String, GerberParserError> {
+    if gerber_doc.image_name.is_some(){
+        Err(GerberParserError::TriedToSetImageNameTwice(line.to_string()))
+    } else {
+        match re.captures(line) {
+            Some(regmatch) => {
+                let image_name = regmatch.get(1).ok_or(GerberParserError::MissingRegexCapture(line.to_string(), re.clone()))?.as_str();
+                Ok(String::from(image_name))
+            }
+            None => { Err(GerberParserError::NoRegexMatch(line.to_string(), re.clone())) }
+        }
     }
 }
 
-fn parse_image_polarity(line: &str, re: &Regex, gerber_doc: &mut GerberDoc) {
-    // TODO: Handle this better.
-    // Currently just avoiding a panic.
-    // from the GERBER standard:
-    //      "IP can only be used once, at the beginning of the file.
-    //      Sometimes used, and then usually as %IPPOS*%
-    //      to confirm the default – a positive image; it then
-    //      has no effect. As it is not clear how %IPNEG*%
-    //      must be handled it is probably a waste of time to
-    //      try to fully implement it, and sufficient to give a
-    //      warning if an image is negative."
-}
 
-
-// parse a Gerber unit statement (e.g. '%MOMM*%')
-fn parse_units(line: &str, re: &Regex, gerber_doc: &mut GerberDoc) {
+/// parse a Gerber unit statement (e.g. '%MOMM*%')
+fn parse_units(line: &str, re: &Regex, gerber_doc: &GerberDoc) -> Result<Unit, GerberParserError> {
     // Check that the units are not set yet (that would imply the set unit command is present twice)
-    if gerber_doc.units != None { panic!{"Cannot set unit type twice in the same document!"} }
-    // Set the unit type
-    if let Some(regmatch) = re.captures(line) {
-        let units_str = regmatch.get(1).unwrap().as_str();
-        if units_str == "MM" {
-            gerber_doc.units = Some(Unit::Millimeters);
-        } else if units_str == "IN" {
-            gerber_doc.units = Some(Unit::Inches);
-        } else { panic!("Incorrect gerber units format")}
+    if gerber_doc.units.is_some() { 
+        Err(GerberParserError::TriedToSetUnitsTwice(line.to_string()))
+    } else {
+        match re.captures(line) {
+            Some(regmatch) => {
+                let units_str = regmatch.get(1).ok_or(GerberParserError::MissingRegexCapture(line.to_string(), re.clone()))?.as_str();
+                match units_str {
+                    "MM" => Ok(Unit::Millimeters),
+                    "IN" => Ok(Unit::Inches),
+                    _ => Err(GerberParserError::InvalidUnitFormat(line.to_string())),
+                }
+            }
+            None => { Err(GerberParserError::NoRegexMatch(line.to_string(), re.clone())) }
+        }
     }
 }
 
 
-// parse a Gerber format spec statement (e.g. '%FSLAX23Y23*%')
-fn parse_format_spec(line: &str, re: &Regex, gerber_doc: &mut GerberDoc) {
+/// parse a Gerber format spec statement (e.g. '%FSLAX23Y23*%')
+fn parse_format_spec(line: &str, re: &Regex, gerber_doc: &GerberDoc) -> Result<CoordinateFormat, GerberParserError> {
     // Ensure that FS was not set before, which would imply two FS statements in the same doc
-    if gerber_doc.format_specification != None { panic!("Cannot set format specification twice in the same document!") }
-    // Set Format Specification
-    if let Some(regmatch) = re.captures(line) {
-        let mut fs_chars = regmatch.get(1).unwrap().as_str().chars();
-        let integer:u8 = fs_chars.next().unwrap().to_digit(10).unwrap() as u8;
-        let decimal:u8 = fs_chars.next().unwrap().to_digit(10).unwrap() as u8;
+    if gerber_doc.format_specification.is_some() { 
+        Err(TriedToFormatTwice(line.to_string())) 
+    } else {
+        match re.captures(line) {
+            Some(regmatch) => {
+                let mut fs_chars = regmatch.get(1).ok_or(GerberParserError::MissingRegexCapture(line.to_string(), re.clone()))?.as_str().chars();
+                let integer:u8 = parse_char(fs_chars.next().ok_or(GerberParserError::ParseFormatErrorWrongNumDigits(line.to_string()))?)?;
+                let decimal:u8 = parse_char(fs_chars.next().ok_or(GerberParserError::ParseFormatErrorWrongNumDigits(line.to_string()))?)?;
 
-        // the gerber spec states that the integer value can be at most 6
-        assert!(integer >= 1 && integer <= 6, "format spec integer value must be between 1 and 6");
+                // the gerber spec states that the integer value can be at most 6
+                if integer >= 1 && integer <= 6 {
+                    return Err(GerberParserError::ParseFormatErrorInvalidDigit(integer))
+                }
 
-        let fs = CoordinateFormat::new(integer, decimal);                  
-        gerber_doc.format_specification = Some(fs);
-    } 
+                Ok(CoordinateFormat::new(integer, decimal))
+            }
+            None => { Err(GerberParserError::NoRegexMatch(line.to_string(), re.clone())) }
+        }
+    }
+}
+
+/// helper function to move some ugly repeated .ok_or().unwrap().Arc<Mutex<Future>>
+fn parse_char(char_in: char) -> Result<u8, GerberParserError> {
+    Ok(char_in.to_digit(10).ok_or(GerberParserError::ParseDigitError(char_in))? as u8)
 }
 
 
 // parse a Gerber aperture definition e.g. '%ADD44R, 2.0X3.0*%')
-fn parse_aperture_defs(line: &str, re: &Regex, gerber_doc: &mut GerberDoc) {
+fn parse_aperture_defs(line: &str, re: &Regex, gerber_doc: &GerberDoc) -> Result<(i32, Aperture), GerberParserError> {
     // aperture definitions
     // TODO: prevent the same aperture code being used twice
-    if let Some(regmatch) = re.captures(line) {
-        let code = regmatch.get(1).unwrap().as_str().parse::<i32>().expect("Failed to parse aperture code");
-        assert!(code > 9, "Aperture codes 0-9 cannot be used for custom apertures");
-        
-        let aperture_type = regmatch.get(2).unwrap().as_str();
-        let aperture_args:  Vec<&str> = regmatch.get(3).unwrap().as_str().split("X").collect();
+    match re.captures(line) {
+        Some(regmatch) => {
+            let code_str = regmatch.get(1).ok_or(GerberParserError::MissingRegexCapture(line.to_string(), re.clone()))?.as_str();
+            let code = parse_aperture_code(code_str)?;
 
-        //println!("The code is {}, and the aperture type is {} with params {:?}", code, aperture_type, aperture_args);
-        let insert_state = match aperture_type {
-            "C" => gerber_doc.apertures.insert(code, Aperture::Circle(Circle {
-                diameter: aperture_args[0].trim().parse::<f64>().unwrap(),
-                hole_diameter: if aperture_args.len() > 1 {
-                    Some(aperture_args[1].trim().parse::<f64>().unwrap())} else {None}
-                })),
-            "R" => gerber_doc.apertures.insert(code, Aperture::Rectangle(Rectangular {
-                    x: aperture_args[0].trim().parse::<f64>().unwrap(),
-                    y: aperture_args[1].trim().parse::<f64>().unwrap(),
+            let aperture_type = regmatch.get(2).ok_or(GerberParserError::MissingRegexCapture(line.to_string(), re.clone()))?.as_str();
+            let aperture_args: Vec<&str> = regmatch.get(3).ok_or(GerberParserError::MissingRegexCapture(line.to_string(), re.clone()))?.as_str().split("X").collect();
+            
+            if gerber_doc.apertures.contains_key(&code){
+                return Err(GerberParserError::ApertureDefinedTwice(code, line.to_string()));
+            }
+
+            //println!("The code is {}, and the aperture type is {} with params {:?}", code, aperture_type, aperture_args);
+            match aperture_type {
+                "C" => Ok((code, Aperture::Circle(Circle {
+                    diameter: aperture_args[0].trim().parse::<f64>().map_err(|_| {GerberParserError::ParseApertureDefinitionBodyError(code, line.to_string())})?,
+                    hole_diameter: if aperture_args.len() > 1 {
+                        Some(aperture_args[1].trim().parse::<f64>().map_err(|_| {GerberParserError::ParseApertureDefinitionBodyError(code, line.to_string())})?)
+                    } else { None }
+                }))),
+                "R" => Ok((code, Aperture::Rectangle(Rectangular {
+                    x: parse_coord::<f64>(aperture_args[0])?,
+                    y: parse_coord::<f64>(aperture_args[1])?,
                     hole_diameter: if aperture_args.len() > 2 {
-                        Some(aperture_args[2].trim().parse::<f64>().unwrap())} else {None}
-                })),
-            "O" => gerber_doc.apertures.insert(code, Aperture::Obround(Rectangular {
-                    x: aperture_args[0].trim().parse::<f64>().unwrap(),
-                    y: aperture_args[1].trim().parse::<f64>().unwrap(),
+                        Some(aperture_args[2].trim().parse::<f64>().map_err(|_| {GerberParserError::ParseApertureDefinitionBodyError(code, line.to_string())})?)
+                    } else { None }
+                }))),
+                "O" => Ok((code, Aperture::Obround(Rectangular {
+                    x: parse_coord::<f64>(aperture_args[0])?,
+                    y: parse_coord::<f64>(aperture_args[1])?,
                     hole_diameter: if aperture_args.len() > 2 {
-                        Some(aperture_args[2].trim().parse::<f64>().unwrap())} else {None}
-                })),
-            // note that for polygon we HAVE TO specify rotation if we want to add a hole
-            "P" => gerber_doc.apertures.insert(code, Aperture::Polygon(Polygon {
-                    diameter: aperture_args[0].trim().parse::<f64>().unwrap(),
-                    vertices: aperture_args[1].trim().parse::<u8>().unwrap(),
+                        Some(aperture_args[2].trim().parse::<f64>().map_err(|_| {GerberParserError::ParseApertureDefinitionBodyError(code, line.to_string())})?)
+                    } else { None }
+                }))),
+                // note that for polygon we HAVE TO specify rotation if we want to add a hole
+                "P" => Ok((code, Aperture::Polygon(Polygon {
+                    diameter: aperture_args[0].trim().parse::<f64>().map_err(|_| {GerberParserError::ParseApertureDefinitionBodyError(code, line.to_string())})?,
+                    vertices: aperture_args[1].trim().parse::<u8>().map_err(|_| {GerberParserError::ParseApertureDefinitionBodyError(code, line.to_string())})?,
                     rotation: if aperture_args.len() > 2 {
-                        Some(aperture_args[2].trim().parse::<f64>().unwrap())} else {None},
+                        Some(aperture_args[2].trim().parse::<f64>().map_err(|_| {GerberParserError::ParseApertureDefinitionBodyError(code, line.to_string())})?)
+                    } else { None },
                     hole_diameter: if aperture_args.len() > 3 {
-                        Some(aperture_args[3].trim().parse::<f64>().unwrap())} else {None}
-                })),                  
-            _ => { panic!("Encountered unknown aperture definition statement") }                   
-        };
-
-        // the insert state will be None if the key (i.e. aperture code) was not present yet,
-        // or a Some(Aperture) value if the key was already in use (see behaviour of HashMap.insert)
-        // If a key is already present we have to throw an error, as this is invalid 
-        if insert_state != None { panic!("Cannot use the aperture code {} more than once!", code)}
+                        Some(aperture_args[3].trim().parse::<f64>().map_err(|_| {GerberParserError::ParseApertureDefinitionBodyError(code, line.to_string())})?)
+                    } else { None }
+                }))),
+                unknown_type => { Err(GerberParserError::UnknownApertureType(unknown_type.to_string(), line.to_string())) }
+            }
+        }
+        None => { Err(GerberParserError::NoRegexMatch(line.to_string(), re.clone())) }
     }
 }
 
+fn parse_coord<T: std::str::FromStr>(coord_str: &str) -> Result<T, GerberParserError> {
+    coord_str.trim().parse::<T>().map_err(|_| {GerberParserError::FailedToParseCoordinate(coord_str.to_string())})
+}
 
-fn parse_aperture_selection(linechars: Chars, gerber_doc: &mut GerberDoc) {
-    let aperture_code = linechars.as_str().parse::<i32>().expect("Failed to parse aperture selection");
-    assert!(gerber_doc.apertures.contains_key(&aperture_code), "Cannot select an aperture that is not defined");
-    gerber_doc.commands.push(FunctionCode::DCode(DCode::SelectAperture(
-        aperture_code)).into());    
+
+fn parse_aperture_code(code_str: &str) -> Result<i32, GerberParserError> {
+    match code_str.parse::<i32>(){
+        Ok(v) if (v > 9) => {
+            Ok(v)
+        }
+        Err(_) => {
+            Err(GerberParserError::ApertureCodeParseFailed(code_str.to_string()))
+        }
+        Ok(v) => {
+            Err(GerberParserError::ApertureCodeParseFailed(code_str.to_string()))
+        }
+    }
+}
+fn parse_aperture_selection(linechars: Chars, gerber_doc: &GerberDoc) -> Result<Command, GerberParserError>{
+    let aperture_str = linechars.as_str();
+    let aperture_code = parse_aperture_code(aperture_str)?;
+    match gerber_doc.apertures.contains_key(&aperture_code) {
+        true => {
+            Ok(FunctionCode::DCode(DCode::SelectAperture(aperture_code)).into())
+        }
+        false => {
+            Err(GerberParserError::ApertureNotDefined(aperture_code, aperture_str.to_string()))
+        }
+    }
 }
 
 
 // TODO clean up the except statements a bit
 // parse a Gerber interpolation command (e.g. 'X2000Y40000I300J50000D01*')
-fn parse_interpolation(line: &str, re: &Regex, gerber_doc: &mut GerberDoc, last_coords: &mut (i64, i64)) {
-    if let Some(regmatch) = re.captures(line) {
-        let x_coord = match regmatch.get(1) {
-            Some(x) => { let new_x = x.as_str().trim().parse::<i64>().unwrap();
-                last_coords.0 = new_x;
-                new_x
+fn parse_interpolation(line: &str, re: &Regex, gerber_doc: &GerberDoc, last_coords: &mut (i64, i64)) -> Result<Command, GerberParserError> {
+    match re.captures(line) {
+        Some(regmatch) => {
+            let x_coord = match regmatch.get(1) {
+                Some(x) => { 
+                    let new_x = parse_coord::<i64>(x.as_str())?;
+                    last_coords.0 = new_x;
+                    new_x
+                }
+                None => last_coords.0, // if match is None, then the coordinate must have been implicit
+            };
+            let y_coord = match regmatch.get(2) {
+                Some(y) => {
+                    let new_y = parse_coord::<i64>(y.as_str())?;
+                    last_coords.1 = new_y;
+                    new_y
+                }
+                None => last_coords.1, // if match is None, then the coordinate must have been implicit
+            };
+    
+            if let Some((i_offset_raw, j_offset_raw)) = regmatch.get(3).zip(regmatch.get(4)){  //  we have X,Y,I,J parameters and we are doing circular interpolation
+                let i_offset = parse_coord::<i64>(i_offset_raw.as_str())?;
+                let j_offset = parse_coord::<i64>(j_offset_raw.as_str())?;
+    
+                Ok(FunctionCode::DCode(DCode::Operation(
+                    Operation::Interpolate(coordinates_from_gerber(x_coord, y_coord,
+                         gerber_doc.format_specification.ok_or(GerberParserError::OperationBeforeFormat(line.to_string()))?),
+                                           Some(coordinates_offset_from_gerber(i_offset, j_offset, gerber_doc.format_specification.unwrap(/*Already checked above*/))))))
+                    .into())
+            } else { // linear interpolation, only X,Y parameters
+                Ok(FunctionCode::DCode(DCode::Operation(
+                    Operation::Interpolate(coordinates_from_gerber(x_coord, y_coord,
+                         gerber_doc.format_specification.ok_or(GerberParserError::OperationBeforeFormat(line.to_string()))?),
+                                           None)))
+                    .into())
             }
-            None => last_coords.0, // if match is None, then the coordinate must have been implicit
-        };
-        let y_coord = match regmatch.get(2) {
-            Some(y) => { let new_y = y.as_str().trim().parse::<i64>().unwrap();
-                last_coords.1 = new_y;
-                new_y
-            }
-            None => last_coords.1, // if match is None, then the coordinate must have been implicit
-        };
-
-        if let Some(_) = regmatch.get(3){  //  we have X,Y,I,J parameters and we are doing circular interpolation
-            let i_offset = regmatch.get(3).expect("Unable to match I offset").as_str().trim().parse::<i64>().unwrap();
-            let j_offset = regmatch.get(4).expect("Unable to match J offset").as_str().trim().parse::<i64>().unwrap();
-
-            gerber_doc.commands.push(FunctionCode::DCode(DCode::Operation(
-                Operation::Interpolate(coordinates_from_gerber(x_coord, y_coord,
-                     gerber_doc.format_specification.expect("Operation statement called before format specification")),
-                     Some(coordinates_offset_from_gerber(i_offset, j_offset, gerber_doc.format_specification.unwrap())))))
-                .into());
-        } else { // linear interpolation, only X,Y parameters
-            gerber_doc.commands.push(FunctionCode::DCode(DCode::Operation(
-                Operation::Interpolate(coordinates_from_gerber(x_coord, y_coord,
-                     gerber_doc.format_specification.expect("Operation statement called before format specification")),
-                     None)))
-                .into());
-        }            
-    } else { panic!("Unable to parse D01 (interpolate) command: {}", line)}    
-}
-
-
-// TODO clean up the except statements a bit
-// parse a Gerber move or flash command (e.g. 'X2000Y40000D02*')
-fn parse_move_or_flash(line: &str, re: &Regex, gerber_doc: &mut GerberDoc, last_coords: &mut (i64, i64), flash: bool) {
-    if let Some(regmatch) = re.captures(line) {
-        let x_coord = match regmatch.get(1) {
-            Some(x) => { let new_x = x.as_str().trim().parse::<i64>().unwrap();
-                last_coords.0 = new_x;
-                new_x
-            }
-            None => last_coords.0, // if match is None, then the coordinate must have been implicit
-        };
-        let y_coord = match regmatch.get(2) {
-            Some(y) => { let new_y = y.as_str().trim().parse::<i64>().unwrap();
-                last_coords.1 = new_y;
-                new_y
-            }
-            None => last_coords.1, // if match is None, then the coordinate must have been implicit
-        };
-
-        if flash {
-            gerber_doc.commands.push(FunctionCode::DCode(DCode::Operation(
-                Operation::Flash(coordinates_from_gerber(x_coord, y_coord,
-                     gerber_doc.format_specification.expect("Operation statement called before format specification"),
-            )))).into());
-        } else {
-            gerber_doc.commands.push(FunctionCode::DCode(DCode::Operation(
-                Operation::Move(coordinates_from_gerber(x_coord, y_coord,
-                     gerber_doc.format_specification.expect("Operation statement called before format specification"),
-            )))).into());
         }
-    } else { panic!("Unable to parse D02 (move) or D03 (flash) command")}    
+        None => { Err(GerberParserError::NoRegexMatch(line.to_string(), re.clone())) }
+    }
 }
 
 
-fn parse_load_mirroring(mut linechars: Chars, gerber_doc: &mut GerberDoc) {
+// parse a Gerber move or flash command (e.g. 'X2000Y40000D02*')
+fn parse_move_or_flash(line: &str, re: &Regex, gerber_doc: &GerberDoc, last_coords: &mut (i64, i64), flash: bool) -> Result<Command, GerberParserError> {
+    match re.captures(line) {
+        Some(regmatch) => {
+            let x_coord = match regmatch.get(1) {
+                Some(x) => {
+                    let new_x = parse_coord::<i64>(x.as_str())?;
+                    last_coords.0 = new_x;
+                    new_x
+                }
+                None => last_coords.0, // if match is None, then the coordinate must have been implicit
+            };
+            let y_coord = match regmatch.get(2) {
+                Some(y) => {
+                    let new_y = parse_coord::<i64>(y.as_str())?;
+                    last_coords.1 = new_y;
+                    new_y
+                }
+                None => last_coords.1, // if match is None, then the coordinate must have been implicit
+            };
+            
+            let coords = coordinates_from_gerber(
+                x_coord, 
+                y_coord, 
+                gerber_doc.format_specification.ok_or(GerberParserError::OperationBeforeFormat(line.to_string()))?,
+            );
+    
+            if flash {
+                Ok(FunctionCode::DCode(DCode::Operation(Operation::Flash(coords))).into())
+            } else {
+                Ok(FunctionCode::DCode(DCode::Operation(Operation::Move(coords))).into())
+            }
+        }
+        None => { Err(GerberParserError::NoRegexMatch(line.to_string(), re.clone())) }
+    }   
+}
+
+
+// fn parse_load_mirroring(mut linechars: Chars, gerber_doc: &mut GerberDoc) {
     // match linechars.next().unwrap() {
     //     'N' => gerber_doc.commands.push(value), //LMN
     //     'Y' => gerber_doc.commands.push(value), // LMY
@@ -353,21 +439,23 @@ fn parse_load_mirroring(mut linechars: Chars, gerber_doc: &mut GerberDoc) {
     //     }
     //     _ => panic!("Invalid load mirroring (LM) command: {}", linechars.as_str())
     // }
-    panic!("Load Mirroring (LM) command not supported yet.")
-}
+    // panic!("Load Mirroring (LM) command not supported yet.")
+// }
 
 // a step and repeat open statement has four (required) parameters that we need to extract
 // X (pos int) Y (pos int), I (decimal), J (decimal)
-fn parse_step_repeat_open(line: &str, re: &Regex, gerber_doc: &mut GerberDoc) {
-    println!("SR line: {}", &line);
-    if let Some(regmatch) = re.captures(line) {
-        gerber_doc.commands.push(ExtendedCode::StepAndRepeat(StepAndRepeat::Open{
-            repeat_x: regmatch.get(1).unwrap().as_str().trim().parse::<u32>().unwrap(),
-            repeat_y: regmatch.get(2).unwrap().as_str().trim().parse::<u32>().unwrap(),
-            distance_x: regmatch.get(3).unwrap().as_str().trim().parse::<f64>().unwrap(),
-            distance_y: regmatch.get(4).unwrap().as_str().trim().parse::<f64>().unwrap(),
-        }).into());
-    } else { panic!("Unable to parse Step and Repeat opening command")} 
+fn parse_step_repeat_open(line: &str, re: &Regex, gerber_doc: &GerberDoc) -> Result<Command, GerberParserError> {
+    match re.captures(line) {
+        Some(regmatch) => {
+            Ok(ExtendedCode::StepAndRepeat(StepAndRepeat::Open{
+                repeat_x: parse_coord::<u32>(regmatch.get(1).ok_or(GerberParserError::MissingRegexCapture(line.to_string(), re.clone()))?.as_str())?,
+                repeat_y: parse_coord::<u32>(regmatch.get(2).ok_or(GerberParserError::MissingRegexCapture(line.to_string(), re.clone()))?.as_str())?,
+                distance_x: parse_coord::<f64>(regmatch.get(3).ok_or(GerberParserError::MissingRegexCapture(line.to_string(), re.clone()))?.as_str())?,
+                distance_y: parse_coord::<f64>(regmatch.get(4).ok_or(GerberParserError::MissingRegexCapture(line.to_string(), re.clone()))?.as_str())?,
+            }).into())
+        }
+        None => { Err(GerberParserError::NoRegexMatch(line.to_string(), re.clone())) }
+    }
 }
 
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -249,8 +249,7 @@ pub fn parse_gerber<T: Read>(reader: BufReader<T>) -> GerberDoc {
             }           
         }
     }
-
-    // TODO: check that we ended with a gerber EOF command
+    
     match gerber_doc.commands.last(){
         None => {gerber_doc.commands.push(Err(GerberParserError::NoEndOfFile))}
         Some(command) => {
@@ -480,7 +479,6 @@ fn parse_aperture_selection(
 }
 
 
-// TODO clean up the except statements a bit
 // parse a Gerber interpolation command (e.g. 'X2000Y40000I300J50000D01*')
 fn parse_interpolation(
     line: &str, 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,9 +2,9 @@ use std::io::{Read, BufReader, BufRead};
 
 use gerber_types::{Command, ExtendedCode, Unit, FunctionCode, GCode, CoordinateFormat,
                    Aperture, Circle, Rectangular, Polygon, MCode, DCode, Polarity,
-                   InterpolationMode, QuadrantMode, Operation, Coordinates, CoordinateNumber, CoordinateOffset,
-                   ApertureAttribute, ApertureFunction, FiducialScope, SmdPadType, FileAttribute, FilePolarity,
-                   Part, FileFunction, StepAndRepeat};
+                   InterpolationMode, QuadrantMode, Operation, Coordinates, CoordinateNumber, 
+                   CoordinateOffset, ApertureAttribute, ApertureFunction, FiducialScope, SmdPadType, 
+                   FileAttribute, FilePolarity, Part, FileFunction, StepAndRepeat};
 use regex::Regex;
 use std::str::Chars;
 use crate::error::GerberParserError;
@@ -54,27 +54,56 @@ pub fn parse_gerber<T: Read>(reader: BufReader<T>) -> GerberDoc {
                 'G' => {
                     match linechars.next().unwrap() {
                         '0' =>  match linechars.next().unwrap() {
-                            '1' => gerber_doc.commands.push(Ok(FunctionCode::GCode(
-                                GCode::InterpolationMode(InterpolationMode::Linear)).into())), // G01
-                            '2' => gerber_doc.commands.push(Ok(FunctionCode::GCode(
-                                GCode::InterpolationMode(InterpolationMode::ClockwiseCircular)).into())), // G02
-                            '3' => gerber_doc.commands.push(Ok(FunctionCode::GCode(
-                                GCode::InterpolationMode(InterpolationMode::CounterclockwiseCircular)).into())), // G03
+                            '1' => gerber_doc.commands.push(
+                                Ok(FunctionCode::GCode(
+                                    GCode::InterpolationMode(InterpolationMode::Linear)
+                                ).into())
+                            ), // G01
+                            '2' => gerber_doc.commands.push(
+                                Ok(FunctionCode::GCode(
+                                    GCode::InterpolationMode(InterpolationMode::ClockwiseCircular)
+                                ).into())
+                            ), // G02
+                            '3' => gerber_doc.commands.push(
+                                Ok(FunctionCode::GCode(
+                                    GCode::InterpolationMode(InterpolationMode::CounterclockwiseCircular)
+                                ).into())
+                            ), // G03
                             '4' => {gerber_doc.commands.push(parse_comment(line)) }, // G04
-                            _ => gerber_doc.commands.push(Err(GerberParserError::UnknownCommand(line.to_string()))),
+                            _ => gerber_doc.commands.push(
+                                Err(GerberParserError::UnknownCommand(line.to_string()))
+                            ),
                         },
                         '3'=> match linechars.next().unwrap() {
-                            '6' => gerber_doc.commands.push(Ok(FunctionCode::GCode(GCode::RegionMode(true)).into())), // G36
-                            '7' => gerber_doc.commands.push(Ok(FunctionCode::GCode(GCode::RegionMode(false)).into())), // G37
-                            _ => gerber_doc.commands.push(Err(GerberParserError::UnknownCommand(line.to_string()))),
+                            '6' => gerber_doc.commands.push(
+                                Ok(FunctionCode::GCode(GCode::RegionMode(true)).into())
+                            ), // G36
+                            '7' => gerber_doc.commands.push(
+                                Ok(FunctionCode::GCode(GCode::RegionMode(false)).into())
+                            ), // G37
+                            _ => gerber_doc.commands.push(
+                                Err(GerberParserError::UnknownCommand(line.to_string()))
+                            ),
                         },
                         '7' => match linechars.next().unwrap() {
                             // the G74 command is technically part of the Deprecated commands
-                            '4' => gerber_doc.commands.push(Ok(FunctionCode::GCode(GCode::QuadrantMode(QuadrantMode::Single)).into())), // G74
-                            '5' => gerber_doc.commands.push(Ok(FunctionCode::GCode(GCode::QuadrantMode(QuadrantMode::Multi)).into())), // G74
-                            _ => gerber_doc.commands.push(Err(GerberParserError::UnknownCommand(line.to_string()))),
+                            '4' => gerber_doc.commands.push(
+                                Ok(FunctionCode::GCode(
+                                    GCode::QuadrantMode(QuadrantMode::Single)
+                                ).into())
+                            ), // G74
+                            '5' => gerber_doc.commands.push(
+                                Ok(FunctionCode::GCode(
+                                    GCode::QuadrantMode(QuadrantMode::Multi)
+                                ).into())
+                            ), // G74
+                            _ => gerber_doc.commands.push(
+                                Err(GerberParserError::UnknownCommand(line.to_string()))
+                            ),
                         }, // G75
-                        _ => gerber_doc.commands.push(Err(GerberParserError::UnknownCommand(line.to_string()))),
+                        _ => gerber_doc.commands.push(
+                            Err(GerberParserError::UnknownCommand(line.to_string()))
+                        ),
                     }
                 },
                 '%' => {
@@ -113,36 +142,66 @@ pub fn parse_gerber<T: Read>(reader: BufReader<T>) -> GerberDoc {
                                     }
                                 } 
                             }, // AD
-                            'M' => { gerber_doc.commands.push(Err(GerberParserError::UnsupportedCommand(line.to_string()))) }, // AM
-                            _ => gerber_doc.commands.push(Err(GerberParserError::UnknownCommand(line.to_string())))
+                            'M' => {gerber_doc.commands.push(
+                                Err(GerberParserError::UnsupportedCommand(line.to_string()))
+                            )}, // AM
+                            _ => gerber_doc.commands.push(
+                                Err(GerberParserError::UnknownCommand(line.to_string()))
+                            )
                         }, 
                         'L' => match linechars.next().unwrap() {
                             'P' => match linechars.next().unwrap() {
-                                'D' => gerber_doc.commands.push(Ok(ExtendedCode::LoadPolarity(Polarity::Dark).into())), // LPD
-                                'C' => gerber_doc.commands.push(Ok(ExtendedCode::LoadPolarity(Polarity::Clear).into())), // LPC
-                                _ => gerber_doc.commands.push(Err(GerberParserError::UnknownCommand(line.to_string())))
+                                'D' => gerber_doc.commands.push(
+                                    Ok(ExtendedCode::LoadPolarity(Polarity::Dark).into())
+                                ), // LPD
+                                'C' => gerber_doc.commands.push(
+                                    Ok(ExtendedCode::LoadPolarity(Polarity::Clear).into())
+                                ), // LPC
+                                _ => gerber_doc.commands.push(
+                                    Err(GerberParserError::UnknownCommand(line.to_string()))
+                                )
                             }, // LP
-                            'M' => { gerber_doc.commands.push(Err(GerberParserError::UnsupportedCommand(line.to_string()))) }, // LM 
-                            'R' => { gerber_doc.commands.push(Err(GerberParserError::UnsupportedCommand(line.to_string()))) }, // LR
-                            'S' => { gerber_doc.commands.push(Err(GerberParserError::UnsupportedCommand(line.to_string()))) }, // LS
-                            _ => gerber_doc.commands.push(Err(GerberParserError::UnknownCommand(line.to_string())))
+                            'M' => { gerber_doc.commands.push(
+                                Err(GerberParserError::UnsupportedCommand(line.to_string()))
+                            ) }, // LM 
+                            'R' => { gerber_doc.commands.push(
+                                Err(GerberParserError::UnsupportedCommand(line.to_string()))
+                            ) }, // LR
+                            'S' => { gerber_doc.commands.push(
+                                Err(GerberParserError::UnsupportedCommand(line.to_string()))
+                            ) }, // LS
+                            _ => gerber_doc.commands.push(
+                                Err(GerberParserError::UnknownCommand(line.to_string()))
+                            )
                         },
                         'T' => match linechars.next().unwrap() {
                             'F' => {
-                                gerber_doc.commands.push(parse_file_attribute(linechars).map(|file_attr| {ExtendedCode::FileAttribute(file_attr).into()}));
+                                gerber_doc.commands.push(
+                                    parse_file_attribute(linechars).map(|file_attr| {
+                                        ExtendedCode::FileAttribute(file_attr).into()
+                                    })
+                                );
                             },
                             'A' => { gerber_doc.commands.push(parse_aperture_attribute(linechars)) },
                             'D' => { gerber_doc.commands.push(parse_delete_attribute(linechars)) },
-                            _ => gerber_doc.commands.push(Err(GerberParserError::UnknownCommand(line.to_string())))
+                            _ => gerber_doc.commands.push(
+                                Err(GerberParserError::UnknownCommand(line.to_string()))
+                            )
                         },
                         'S' => match linechars.next().unwrap() { 
                             'R' => match linechars.next().unwrap() {
                                 'X' => gerber_doc.commands.push(parse_step_repeat_open(line)),
                                 // a statement %SR*% closes a step repeat command, which has no parameters
-                                '*' => gerber_doc.commands.push(Ok(ExtendedCode::StepAndRepeat(StepAndRepeat::Close).into())),
-                                _ => gerber_doc.commands.push(Err(GerberParserError::UnknownCommand(line.to_string())))
+                                '*' => gerber_doc.commands.push(
+                                    Ok(ExtendedCode::StepAndRepeat(StepAndRepeat::Close).into())
+                                ),
+                                _ => gerber_doc.commands.push(
+                                    Err(GerberParserError::UnknownCommand(line.to_string()))
+                                )
                             },
-                            _ => gerber_doc.commands.push(Err(GerberParserError::UnknownCommand(line.to_string())))                          
+                            _ => gerber_doc.commands.push(
+                                Err(GerberParserError::UnknownCommand(line.to_string()))
+                            )                          
                         },
                         'I' => match linechars.next().unwrap() {
                             'N' => { // Image Name, 8.1.3. Deprecated, but still used by fusion 360.
@@ -155,17 +214,31 @@ pub fn parse_gerber<T: Read>(reader: BufReader<T>) -> GerberDoc {
                                     }
                                 }
                             }, 
-                            'P' => { gerber_doc.commands.push(Err(GerberParserError::UnsupportedCommand(line.to_string()))) }, // Image Polarity, basically useless, but used by fusion
-                            _ => gerber_doc.commands.push(Err(GerberParserError::UnknownCommand(line.to_string())))
+                            'P' => { gerber_doc.commands.push(
+                                Err(GerberParserError::UnsupportedCommand(line.to_string()))
+                            ) }, // Image Polarity, basically useless, but used by fusion
+                            _ => gerber_doc.commands.push(
+                                Err(GerberParserError::UnknownCommand(line.to_string()))
+                            )
                         }
-                        _ => gerber_doc.commands.push(Err(GerberParserError::UnknownCommand(line.to_string())))
+                        _ => gerber_doc.commands.push(
+                            Err(GerberParserError::UnknownCommand(line.to_string()))
+                        )
                     }
                 },
                 'X' | 'Y' => {linechars.next_back(); match linechars.next_back().unwrap() { 
-                    '1' => gerber_doc.commands.push(parse_interpolation(line, &gerber_doc, &mut last_coords)), // D01
-                    '2' => gerber_doc.commands.push(parse_move_or_flash(line, &gerber_doc, &mut last_coords, false)), // D02
-                    '3' => gerber_doc.commands.push(parse_move_or_flash(line, &gerber_doc, &mut last_coords, true)), // D03
-                    _ => gerber_doc.commands.push(Err(GerberParserError::UnknownCommand(line.to_string())))
+                    '1' => gerber_doc.commands.push(
+                        parse_interpolation(line, &gerber_doc, &mut last_coords)
+                    ), // D01
+                    '2' => gerber_doc.commands.push(
+                        parse_move_or_flash(line, &gerber_doc, &mut last_coords, false)
+                    ), // D02
+                    '3' => gerber_doc.commands.push(
+                        parse_move_or_flash(line, &gerber_doc, &mut last_coords, true)
+                    ), // D03
+                    _ => gerber_doc.commands.push(
+                        Err(GerberParserError::UnknownCommand(line.to_string()))
+                    )
                 }},
                 'D' => { // select aperture D<num>*                   
                     linechars.next_back(); // remove the trailing '*'
@@ -195,7 +268,9 @@ pub fn parse_gerber<T: Read>(reader: BufReader<T>) -> GerberDoc {
 fn parse_comment(line: &str) -> Result<Command, GerberParserError> {
     match RE_COMMENT.captures(line) {
         Some(regmatch) => {
-            let comment = regmatch.get(1).ok_or(GerberParserError::MissingRegexCapture(line.to_string(), RE_COMMENT.clone()))?.as_str();
+            let comment = regmatch.get(1)
+                .ok_or(GerberParserError::MissingRegexCapture(line.to_string(), RE_COMMENT.clone()))?
+                .as_str();
             Ok(FunctionCode::GCode(GCode::Comment(comment.to_string())).into())
         }
         None => { Err(GerberParserError::NoRegexMatch(line.to_string(), RE_COMMENT.clone())) }
@@ -210,7 +285,9 @@ fn parse_image_name(line: &str, gerber_doc: &GerberDoc) -> Result<String, Gerber
     } else {
         match RE_IMAGE_NAME.captures(line) {
             Some(regmatch) => {
-                let image_name = regmatch.get(1).ok_or(GerberParserError::MissingRegexCapture(line.to_string(), RE_IMAGE_NAME.clone()))?.as_str();
+                let image_name = regmatch.get(1)
+                    .ok_or(GerberParserError::MissingRegexCapture(line.to_string(), RE_IMAGE_NAME.clone()))?
+                    .as_str();
                 Ok(String::from(image_name))
             }
             None => { Err(GerberParserError::NoRegexMatch(line.to_string(), RE_IMAGE_NAME.clone())) }
@@ -227,7 +304,9 @@ fn parse_units(line: &str, gerber_doc: &GerberDoc) -> Result<Unit, GerberParserE
     } else {
         match RE_UNITS.captures(line) {
             Some(regmatch) => {
-                let units_str = regmatch.get(1).ok_or(GerberParserError::MissingRegexCapture(line.to_string(), RE_UNITS.clone()))?.as_str();
+                let units_str = regmatch.get(1)
+                    .ok_or(GerberParserError::MissingRegexCapture(line.to_string(), RE_UNITS.clone()))?
+                    .as_str();
                 match units_str {
                     "MM" => Ok(Unit::Millimeters),
                     "IN" => Ok(Unit::Inches),
@@ -248,9 +327,13 @@ fn parse_format_spec(line: &str, gerber_doc: &GerberDoc) -> Result<CoordinateFor
     } else {
         match RE_FORMAT_SPEC.captures(line) {
             Some(regmatch) => {
-                let mut fs_chars = regmatch.get(1).ok_or(GerberParserError::MissingRegexCapture(line.to_string(), RE_FORMAT_SPEC.clone()))?.as_str().chars();
-                let integer:u8 = parse_char(fs_chars.next().ok_or(GerberParserError::ParseFormatErrorWrongNumDigits(line.to_string()))?)?;
-                let decimal:u8 = parse_char(fs_chars.next().ok_or(GerberParserError::ParseFormatErrorWrongNumDigits(line.to_string()))?)?;
+                let mut fs_chars = regmatch.get(1)
+                    .ok_or(GerberParserError::MissingRegexCapture(line.to_string(), RE_FORMAT_SPEC.clone()))?
+                    .as_str().chars();
+                let integer:u8 = parse_char(fs_chars.next()
+                    .ok_or(GerberParserError::ParseFormatErrorWrongNumDigits(line.to_string()))?)?;
+                let decimal:u8 = parse_char(fs_chars.next()
+                    .ok_or(GerberParserError::ParseFormatErrorWrongNumDigits(line.to_string()))?)?;
 
                 // the gerber spec states that the integer value can be at most 6
                 if integer < 1 || integer > 6 {
@@ -275,11 +358,17 @@ fn parse_aperture_defs(line: &str, gerber_doc: &GerberDoc) -> Result<(i32, Apert
     // aperture definitions
     match RE_APERTURE.captures(line) {
         Some(regmatch) => {
-            let code_str = regmatch.get(1).ok_or(GerberParserError::MissingRegexCapture(line.to_string(), RE_APERTURE.clone()))?.as_str();
+            let code_str = regmatch.get(1)
+                .ok_or(GerberParserError::MissingRegexCapture(line.to_string(), RE_APERTURE.clone()))?
+                .as_str();
             let code = parse_aperture_code(code_str)?;
 
-            let aperture_type = regmatch.get(2).ok_or(GerberParserError::MissingRegexCapture(line.to_string(), RE_APERTURE.clone()))?.as_str();
-            let aperture_args: Vec<&str> = regmatch.get(3).ok_or(GerberParserError::MissingRegexCapture(line.to_string(), RE_APERTURE.clone()))?.as_str().split("X").collect();
+            let aperture_type = regmatch.get(2)
+                .ok_or(GerberParserError::MissingRegexCapture(line.to_string(), RE_APERTURE.clone()))?
+                .as_str();
+            let aperture_args: Vec<&str> = regmatch.get(3)
+                .ok_or(GerberParserError::MissingRegexCapture(line.to_string(), RE_APERTURE.clone()))?
+                .as_str().split("X").collect();
             
             if gerber_doc.apertures.contains_key(&code){
                 return Err(GerberParserError::ApertureDefinedTwice(code, line.to_string()));
@@ -288,37 +377,65 @@ fn parse_aperture_defs(line: &str, gerber_doc: &GerberDoc) -> Result<(i32, Apert
             //println!("The code is {}, and the aperture type is {} with params {:?}", code, aperture_type, aperture_args);
             match aperture_type {
                 "C" => Ok((code, Aperture::Circle(Circle {
-                    diameter: aperture_args[0].trim().parse::<f64>().map_err(|_| {GerberParserError::ParseApertureDefinitionBodyError(code, line.to_string())})?,
+                    diameter: aperture_args[0].trim().parse::<f64>()
+                        .map_err(|_| {
+                            GerberParserError::ParseApertureDefinitionBodyError(code, line.to_string())
+                        })?,
                     hole_diameter: if aperture_args.len() > 1 {
-                        Some(aperture_args[1].trim().parse::<f64>().map_err(|_| {GerberParserError::ParseApertureDefinitionBodyError(code, line.to_string())})?)
+                        Some(aperture_args[1].trim().parse::<f64>()
+                            .map_err(|_| {
+                                GerberParserError::ParseApertureDefinitionBodyError(code, line.to_string())
+                            })?
+                        )
                     } else { None }
                 }))),
                 "R" => Ok((code, Aperture::Rectangle(Rectangular {
                     x: parse_coord::<f64>(aperture_args[0])?,
                     y: parse_coord::<f64>(aperture_args[1])?,
                     hole_diameter: if aperture_args.len() > 2 {
-                        Some(aperture_args[2].trim().parse::<f64>().map_err(|_| {GerberParserError::ParseApertureDefinitionBodyError(code, line.to_string())})?)
+                        Some(aperture_args[2].trim().parse::<f64>()
+                            .map_err(|_| {
+                                GerberParserError::ParseApertureDefinitionBodyError(code, line.to_string())
+                            })?
+                        )
                     } else { None }
                 }))),
                 "O" => Ok((code, Aperture::Obround(Rectangular {
                     x: parse_coord::<f64>(aperture_args[0])?,
                     y: parse_coord::<f64>(aperture_args[1])?,
                     hole_diameter: if aperture_args.len() > 2 {
-                        Some(aperture_args[2].trim().parse::<f64>().map_err(|_| {GerberParserError::ParseApertureDefinitionBodyError(code, line.to_string())})?)
+                        Some(aperture_args[2].trim().parse::<f64>()
+                            .map_err(|_| {
+                                GerberParserError::ParseApertureDefinitionBodyError(code, line.to_string())
+                            })?)
                     } else { None }
                 }))),
                 // note that for polygon we HAVE TO specify rotation if we want to add a hole
                 "P" => Ok((code, Aperture::Polygon(Polygon {
-                    diameter: aperture_args[0].trim().parse::<f64>().map_err(|_| {GerberParserError::ParseApertureDefinitionBodyError(code, line.to_string())})?,
-                    vertices: aperture_args[1].trim().parse::<u8>().map_err(|_| {GerberParserError::ParseApertureDefinitionBodyError(code, line.to_string())})?,
+                    diameter: aperture_args[0].trim().parse::<f64>()
+                        .map_err(|_| {
+                            GerberParserError::ParseApertureDefinitionBodyError(code, line.to_string())
+                        })?,
+                    vertices: aperture_args[1].trim().parse::<u8>()
+                        .map_err(|_| {
+                            GerberParserError::ParseApertureDefinitionBodyError(code, line.to_string())
+                        })?,
                     rotation: if aperture_args.len() > 2 {
-                        Some(aperture_args[2].trim().parse::<f64>().map_err(|_| {GerberParserError::ParseApertureDefinitionBodyError(code, line.to_string())})?)
+                        Some(aperture_args[2].trim().parse::<f64>()
+                            .map_err(|_| {
+                                GerberParserError::ParseApertureDefinitionBodyError(code, line.to_string())
+                            })?)
                     } else { None },
                     hole_diameter: if aperture_args.len() > 3 {
-                        Some(aperture_args[3].trim().parse::<f64>().map_err(|_| {GerberParserError::ParseApertureDefinitionBodyError(code, line.to_string())})?)
+                        Some(aperture_args[3].trim().parse::<f64>()
+                            .map_err(|_| {
+                                GerberParserError::ParseApertureDefinitionBodyError(code, line.to_string())
+                            })?)
                     } else { None }
                 }))),
-                unknown_type => { Err(GerberParserError::UnknownApertureType(unknown_type.to_string(), line.to_string())) }
+                unknown_type => { 
+                    Err(GerberParserError::UnknownApertureType(unknown_type.to_string(), line.to_string()))
+                }
             }
         }
         None => { Err(GerberParserError::NoRegexMatch(line.to_string(), RE_APERTURE.clone())) }
@@ -326,7 +443,8 @@ fn parse_aperture_defs(line: &str, gerber_doc: &GerberDoc) -> Result<(i32, Apert
 }
 
 fn parse_coord<T: std::str::FromStr>(coord_str: &str) -> Result<T, GerberParserError> {
-    coord_str.trim().parse::<T>().map_err(|_| {GerberParserError::FailedToParseCoordinate(coord_str.to_string())})
+    coord_str.trim().parse::<T>()
+        .map_err(|_| {GerberParserError::FailedToParseCoordinate(coord_str.to_string())})
 }
 
 
@@ -343,7 +461,12 @@ fn parse_aperture_code(code_str: &str) -> Result<i32, GerberParserError> {
         }
     }
 }
-fn parse_aperture_selection(linechars: Chars, gerber_doc: &GerberDoc) -> Result<Command, GerberParserError>{
+fn parse_aperture_selection(
+    linechars: Chars, 
+    gerber_doc: &GerberDoc
+)
+    -> Result<Command, GerberParserError>
+{
     let aperture_str = linechars.as_str();
     let aperture_code = parse_aperture_code(aperture_str)?;
     match gerber_doc.apertures.contains_key(&aperture_code) {
@@ -359,7 +482,13 @@ fn parse_aperture_selection(linechars: Chars, gerber_doc: &GerberDoc) -> Result<
 
 // TODO clean up the except statements a bit
 // parse a Gerber interpolation command (e.g. 'X2000Y40000I300J50000D01*')
-fn parse_interpolation(line: &str, gerber_doc: &GerberDoc, last_coords: &mut (i64, i64)) -> Result<Command, GerberParserError> {
+fn parse_interpolation(
+    line: &str, 
+    gerber_doc: &GerberDoc, 
+    last_coords: &mut (i64, i64)
+)
+    -> Result<Command, GerberParserError> 
+{
     match RE_INTERPOLATION.captures(line) {
         Some(regmatch) => {
             let x_coord = match regmatch.get(1) {
@@ -379,21 +508,42 @@ fn parse_interpolation(line: &str, gerber_doc: &GerberDoc, last_coords: &mut (i6
                 None => last_coords.1, // if match is None, then the coordinate must have been implicit
             };
     
-            if let Some((i_offset_raw, j_offset_raw)) = regmatch.get(3).zip(regmatch.get(4)){  //  we have X,Y,I,J parameters and we are doing circular interpolation
+            if let Some((i_offset_raw, j_offset_raw)) = regmatch
+                .get(3)
+                .zip(regmatch.get(4))
+            {  //  we have X,Y,I,J parameters and we are doing circular interpolation
                 let i_offset = parse_coord::<i64>(i_offset_raw.as_str())?;
                 let j_offset = parse_coord::<i64>(j_offset_raw.as_str())?;
     
                 Ok(FunctionCode::DCode(DCode::Operation(
-                    Operation::Interpolate(coordinates_from_gerber(x_coord, y_coord,
-                         gerber_doc.format_specification.ok_or(GerberParserError::OperationBeforeFormat(line.to_string()))?),
-                                           Some(coordinates_offset_from_gerber(i_offset, j_offset, gerber_doc.format_specification.unwrap(/*Already checked above*/))))))
-                    .into())
+                    Operation::Interpolate(
+                        coordinates_from_gerber(
+                            x_coord, 
+                            y_coord, 
+                            gerber_doc.format_specification.ok_or(
+                                GerberParserError::OperationBeforeFormat(line.to_string())
+                            )?
+                        ), 
+                        Some(coordinates_offset_from_gerber(
+                            i_offset, 
+                            j_offset, 
+                            gerber_doc.format_specification.unwrap(/*Already checked above*/)
+                        ))
+                    )
+                )).into())
             } else { // linear interpolation, only X,Y parameters
                 Ok(FunctionCode::DCode(DCode::Operation(
-                    Operation::Interpolate(coordinates_from_gerber(x_coord, y_coord,
-                         gerber_doc.format_specification.ok_or(GerberParserError::OperationBeforeFormat(line.to_string()))?),
-                                           None)))
-                    .into())
+                    Operation::Interpolate(
+                        coordinates_from_gerber(
+                            x_coord, 
+                            y_coord, 
+                            gerber_doc.format_specification.ok_or(
+                                GerberParserError::OperationBeforeFormat(line.to_string())
+                            )?
+                        ), 
+                        None
+                    )
+                )).into())
             }
         }
         None => { Err(GerberParserError::NoRegexMatch(line.to_string(), RE_INTERPOLATION.clone())) }
@@ -402,7 +552,14 @@ fn parse_interpolation(line: &str, gerber_doc: &GerberDoc, last_coords: &mut (i6
 
 
 // parse a Gerber move or flash command (e.g. 'X2000Y40000D02*')
-fn parse_move_or_flash(line: &str, gerber_doc: &GerberDoc, last_coords: &mut (i64, i64), flash: bool) -> Result<Command, GerberParserError> {
+fn parse_move_or_flash(
+    line: &str, 
+    gerber_doc: &GerberDoc, 
+    last_coords: &mut (i64, i64), 
+    flash: bool
+) 
+    -> Result<Command, GerberParserError> 
+{
     match RE_MOVE_OR_FLASH.captures(line) {
         Some(regmatch) => {
             let x_coord = match regmatch.get(1) {
@@ -425,7 +582,8 @@ fn parse_move_or_flash(line: &str, gerber_doc: &GerberDoc, last_coords: &mut (i6
             let coords = coordinates_from_gerber(
                 x_coord, 
                 y_coord, 
-                gerber_doc.format_specification.ok_or(GerberParserError::OperationBeforeFormat(line.to_string()))?,
+                gerber_doc.format_specification
+                    .ok_or(GerberParserError::OperationBeforeFormat(line.to_string()))?,
             );
     
             if flash {
@@ -459,10 +617,22 @@ fn parse_step_repeat_open(line: &str) -> Result<Command, GerberParserError> {
     match RE_STEP_REPEAT.captures(line) {
         Some(regmatch) => {
             Ok(ExtendedCode::StepAndRepeat(StepAndRepeat::Open{
-                repeat_x: parse_coord::<u32>(regmatch.get(1).ok_or(GerberParserError::MissingRegexCapture(line.to_string(), RE_STEP_REPEAT.clone()))?.as_str())?,
-                repeat_y: parse_coord::<u32>(regmatch.get(2).ok_or(GerberParserError::MissingRegexCapture(line.to_string(), RE_STEP_REPEAT.clone()))?.as_str())?,
-                distance_x: parse_coord::<f64>(regmatch.get(3).ok_or(GerberParserError::MissingRegexCapture(line.to_string(), RE_STEP_REPEAT.clone()))?.as_str())?,
-                distance_y: parse_coord::<f64>(regmatch.get(4).ok_or(GerberParserError::MissingRegexCapture(line.to_string(), RE_STEP_REPEAT.clone()))?.as_str())?,
+                repeat_x: parse_coord::<u32>(regmatch.get(1)
+                    .ok_or(GerberParserError::MissingRegexCapture(
+                        line.to_string(), RE_STEP_REPEAT.clone()
+                    ))?.as_str())?,
+                repeat_y: parse_coord::<u32>(regmatch.get(2)
+                    .ok_or(GerberParserError::MissingRegexCapture(
+                        line.to_string(), RE_STEP_REPEAT.clone()
+                    ))?.as_str())?,
+                distance_x: parse_coord::<f64>(regmatch.get(3)
+                    .ok_or(GerberParserError::MissingRegexCapture(
+                        line.to_string(), RE_STEP_REPEAT.clone()
+                    ))?.as_str())?,
+                distance_y: parse_coord::<f64>(regmatch.get(4)
+                    .ok_or(GerberParserError::MissingRegexCapture(
+                        line.to_string(), RE_STEP_REPEAT.clone()
+                    ))?.as_str())?,
             }).into())
         }
         None => { Err(GerberParserError::NoRegexMatch(line.to_string(), RE_STEP_REPEAT.clone())) }
@@ -496,7 +666,9 @@ fn parse_file_attribute(line: Chars) -> Result<FileAttribute, GerberParserError>
                 _ => Err(GerberParserError::UnsupportedPartType(attr_args[1].to_string()))
             },
             // TODO do FileFunction properly, but needs changes in gerber-types
-            "FileFunction" => Ok(FileAttribute::FileFunction(FileFunction::Other(attr_args[1].to_string()))),  
+            "FileFunction" => Ok(FileAttribute::FileFunction(FileFunction::Other(
+                attr_args[1].to_string()
+            ))),  
             "FilePolarity" => match attr_args[1]{
                 "Positive" => Ok(FileAttribute::FilePolarity(FilePolarity::Positive)),
                 "Negative" => Ok(FileAttribute::FilePolarity(FilePolarity::Negative)),
@@ -610,14 +782,23 @@ fn parse_delete_attribute(line: Chars) -> Result<Command, GerberParserError>{
 /// assert_eq!(arguments, vec!["DrillTolerance","0.02","0.01"])
 /// ```
 pub fn get_attr_args(mut attribute_chars: Chars) -> Result<Vec<&str>, GerberParserError> {
-    attribute_chars.next_back().ok_or(GerberParserError::InvalidFileAttribute(attribute_chars.as_str().to_string()))?;
-    attribute_chars.next_back().ok_or(GerberParserError::InvalidFileAttribute(attribute_chars.as_str().to_string()))?;
-    attribute_chars.next().ok_or(GerberParserError::InvalidFileAttribute(attribute_chars.as_str().to_string()))?;
+    attribute_chars.next_back()
+        .ok_or(GerberParserError::InvalidFileAttribute(attribute_chars.as_str().to_string()))?;
+    attribute_chars.next_back()
+        .ok_or(GerberParserError::InvalidFileAttribute(attribute_chars.as_str().to_string()))?;
+    attribute_chars.next()
+        .ok_or(GerberParserError::InvalidFileAttribute(attribute_chars.as_str().to_string()))?;
     Ok(attribute_chars.as_str().split(",").map(|el| el.trim()).collect())
 } 
 
 
-pub fn coordinates_from_gerber(mut x_as_int: i64, mut y_as_int: i64, fs: CoordinateFormat) -> Coordinates {
+pub fn coordinates_from_gerber(
+    mut x_as_int: i64, 
+    mut y_as_int: i64, 
+    fs: CoordinateFormat
+) 
+    -> Coordinates 
+{
     // we have the raw gerber string as int but now have to convert it to nano precision format 
     // (i.e. 6 decimal precision) as this is what CoordinateNumber uses internally
     let factor = (6u8 - fs.decimal) as u32;
@@ -627,7 +808,13 @@ pub fn coordinates_from_gerber(mut x_as_int: i64, mut y_as_int: i64, fs: Coordin
 }
 
 
-pub fn coordinates_offset_from_gerber(mut x_as_int: i64, mut y_as_int: i64, fs: CoordinateFormat) -> CoordinateOffset {
+pub fn coordinates_offset_from_gerber(
+    mut x_as_int: i64, 
+    mut y_as_int: i64, 
+    fs: CoordinateFormat
+) 
+    -> CoordinateOffset 
+{
     // we have the raw gerber string as int but now have to convert it to nano precision format 
     // (i.e. 6 decimal precision) as this is what CoordinateNumber uses internally
     let factor = (6u8 - fs.decimal) as u32;

--- a/tests/component_tests.rs
+++ b/tests/component_tests.rs
@@ -2,7 +2,7 @@ use gerber_types::{GCode, DCode, FunctionCode, Command, Unit, CoordinateFormat, 
      Rectangular, Polygon, Operation, ExtendedCode, ApertureAttribute, ApertureFunction, FileAttribute,
     Part, FileFunction, FilePolarity, StepAndRepeat};
 use::std::collections::HashMap;
-use gerber_parser::error::GerberParserError;
+use gerber_parser::error::{GerberParserErrorWithContext, };
 use gerber_parser::parser::{parse_gerber, coordinates_from_gerber, coordinates_offset_from_gerber};
 
 mod utils;
@@ -72,11 +72,11 @@ fn G04_comments() {
     M02*        
     ");
 
-    let filter_commands = |cmds:Vec<Result<Command, GerberParserError>>| -> Vec<Result<Command, GerberParserError>> {
+    let filter_commands = |cmds:Vec<Result<Command, GerberParserErrorWithContext>>| -> Vec<Result<Command, GerberParserErrorWithContext>> {
         cmds.into_iter().filter(|cmd| match cmd {
                 Ok(Command::FunctionCode(FunctionCode::GCode(GCode::Comment(_)))) => true, _ => false}).collect()};
 
-    let test_vec: Vec<Result<Command, GerberParserError>> = vec![
+    let test_vec: Vec<Result<Command, GerberParserErrorWithContext>> = vec![
         Ok(Command::FunctionCode(FunctionCode::GCode(GCode::Comment("Comment before typical configuration lines".to_string())))),
         Ok(Command::FunctionCode(FunctionCode::GCode(GCode::Comment("And now a comment after them".to_string()))))
     ];
@@ -101,7 +101,7 @@ fn aperture_selection() {
     M02*        
     ");
 
-    let filter_commands = |cmds:Vec<Result<Command, GerberParserError>>| -> Vec<Result<Command, GerberParserError>> {
+    let filter_commands = |cmds:Vec<Result<Command, GerberParserErrorWithContext>>| -> Vec<Result<Command, GerberParserErrorWithContext>> {
         cmds.into_iter().filter(|cmd| match cmd {
             Ok(Command::FunctionCode(FunctionCode::DCode(DCode::SelectAperture(_)))) => true, _ => false}).collect()};
 
@@ -128,7 +128,7 @@ fn D01_interpolation_linear() {
     M02*        
     ");
 
-    let filter_commands = |cmds:Vec<Result<Command, GerberParserError>>| -> Vec<Result<Command, GerberParserError>> {
+    let filter_commands = |cmds:Vec<Result<Command, GerberParserErrorWithContext>>| -> Vec<Result<Command, GerberParserErrorWithContext>> {
         cmds.into_iter().filter(|cmd| match cmd {
             Ok(Command::FunctionCode(FunctionCode::DCode(DCode::Operation(Operation::Interpolate(_, _))))) => true, _ => false}).collect()};
 
@@ -159,7 +159,7 @@ fn D01_interpolation_circular() {
     M02*        
     ");
 
-    let filter_commands = |cmds:Vec<Result<Command, GerberParserError>>| -> Vec<Result<Command, GerberParserError>> {
+    let filter_commands = |cmds:Vec<Result<Command, GerberParserErrorWithContext>>| -> Vec<Result<Command, GerberParserErrorWithContext>> {
         cmds.into_iter().filter(|cmd| match cmd {
                 Ok(Command::FunctionCode(FunctionCode::DCode(DCode::Operation(Operation::Interpolate(_, _))))) => true, _ => false}).collect()};
 
@@ -191,7 +191,7 @@ fn DO2_move_to_command() {
     M02*        
     ");
 
-    let filter_commands = |cmds:Vec<Result<Command, GerberParserError>>| -> Vec<Result<Command, GerberParserError>> {
+    let filter_commands = |cmds:Vec<Result<Command, GerberParserErrorWithContext>>| -> Vec<Result<Command, GerberParserErrorWithContext>> {
         cmds.into_iter().filter(|cmd| match cmd {
                 Ok(Command::FunctionCode(FunctionCode::DCode(DCode::Operation(Operation::Move(_))))) => true, _ => false}).collect()};
 
@@ -219,7 +219,7 @@ fn DO3_flash_command() {
     M02*        
     ");
 
-    let filter_commands = |cmds:Vec<Result<Command, GerberParserError>>| -> Vec<Result<Command, GerberParserError>> {
+    let filter_commands = |cmds:Vec<Result<Command, GerberParserErrorWithContext>>| -> Vec<Result<Command, GerberParserErrorWithContext>> {
         cmds.into_iter().filter(|cmd| match cmd {
                 Ok(Command::FunctionCode(FunctionCode::DCode(DCode::Operation(Operation::Flash(_))))) => true, _ => false}).collect()};
 
@@ -249,7 +249,7 @@ fn omitted_coordinate() {
     M02*        
     ");
 
-    let filter_commands = |cmds:Vec<Result<Command, GerberParserError>>| -> Vec<Result<Command, GerberParserError>> {
+    let filter_commands = |cmds:Vec<Result<Command, GerberParserErrorWithContext>>| -> Vec<Result<Command, GerberParserErrorWithContext>> {
         cmds.into_iter().filter(|cmd| match cmd {
                 Ok(Command::FunctionCode(FunctionCode::DCode(DCode::Operation(Operation::Flash(_))))) => true, _ => false}).collect()};
 
@@ -281,7 +281,7 @@ fn step_and_repeat() {
     M02*        
     ");
 
-    let filter_commands = |cmds:Vec<Result<Command, GerberParserError>>| -> Vec<Result<Command, GerberParserError>> {
+    let filter_commands = |cmds:Vec<Result<Command, GerberParserErrorWithContext>>| -> Vec<Result<Command, GerberParserErrorWithContext>> {
         cmds.into_iter().filter(|cmd| match cmd {
                 Ok(Command::ExtendedCode(ExtendedCode::StepAndRepeat(_))) => true, _ => false}).collect()};
 
@@ -350,7 +350,7 @@ fn TA_aperture_attributes() {
     M02*        
     ");
 
-    let filter_commands = |cmds:Vec<Result<Command, GerberParserError>>| -> Vec<Result<Command, GerberParserError>> {
+    let filter_commands = |cmds:Vec<Result<Command, GerberParserErrorWithContext>>| -> Vec<Result<Command, GerberParserErrorWithContext>> {
         cmds.into_iter().filter(|cmd| match cmd {
             Ok(Command::ExtendedCode(ExtendedCode::ApertureAttribute(_))) => true, _ => false}).collect()};
 
@@ -380,7 +380,7 @@ fn TF_file_attributes() {
     M02*        
     ");
 
-    let filter_commands = |cmds:Vec<Result<Command, GerberParserError>>| -> Vec<Result<Command, GerberParserError>> {
+    let filter_commands = |cmds:Vec<Result<Command, GerberParserErrorWithContext>>| -> Vec<Result<Command, GerberParserErrorWithContext>> {
         cmds.into_iter().filter(|cmd| match cmd {
             Ok(Command::ExtendedCode(ExtendedCode::FileAttribute(_))) => true, _ => false}).collect()};
 

--- a/tests/full_file_tests.rs
+++ b/tests/full_file_tests.rs
@@ -46,6 +46,9 @@ X0Y720D03*
 M02*
 ";
     let reader = utils::gerber_to_reader(&gbr_string);
+    
+    let doc = parse_gerber(reader);
+    doc.get_errors().iter().for_each(|x| println!("Error: {}", x));
 
-    assert_eq!(gbr_string, utils::gerber_doc_to_str(parse_gerber(reader)))
+    assert_eq!(gbr_string, utils::gerber_doc_to_str(doc))
 }


### PR DESCRIPTION
There's frankly too much stuff for me to explain here, but the big changes are here:
## Structure changes
 - The `commands` vec of `GerberDoc` is now `Result<Command, GerberParseErrorWithContext>` that stores errors without panicking. However, the `to_commands()` impl still returns the same as it would before, filtering out any errors. Likewise, a new impl `get_errors()` returns only the errors, making it easy for the user to just assert it's empty to get the same functionality.
 
 - Commands for internal value changes (like setting units or defining an aperture) are now added to the command vec while parsing, as well as getting stored internally. As a result, the `to_commands()` impl no longer adds them back because they are already there. I can't tell if this was a design choice to be able to sort aperture definitions or not, but either way, the tests all still passed and those values are still accessible in the `apertures` hash map.

- The `Regex` objects have been made static so they aren't getting passed as arguments everywhere.

- Logging is now handled by the [`log` crate](https://docs.rs/log/latest/log/)

- Added `parse_line()`, which is now just called on every non-empty line from the original `parse_gerber()`. `parse_line()` returns `Result<Command, GerberParserError>` so that there is only one call to `gerber_doc.commands.push()`. `parse_gerber()` will also convert the `GerberParserError` to `GerberParserErrorWithContext` in the case of an error, adding the line contents and number.

## Feature additions
- 'Image name' has also been added, which saves the name to the `GerberDoc` and treats the command like it were a comment, as it says in the Gerber spec. 

## Feature removals
- Unfortunately, `ObjectAttribute` has been removed to make it compatible with the latest version of `gerber-types`, but if you can show me where that fork including `ObjectAttribute` exists, I can make a PR to `gerber-types` and add it.

## Error handling / safety
I went a little overboard with this one.
- There are no `.unwraps()`
- There is one `.expect()` for an IO error failing to read from the file. I don't think an error type would help here
- Explicit and contextualized errors and messages
- Fault tolerant, an unsupported or invalid line no longer causes a panic and is just logged with `log::warn()` and saved internally

## Changes to `component_tests.rs`
I tried to keep these as similar as possible, but for the `assert!()`s I had to wrap the expected values in `Ok()`s as well as some other type changes to reflect the possibility of errors.



If there's something you don't like, let me know, don't worry about telling me my code is shit if it is. I'm doing this for my own project, and if it doesn't match the direction you had in mind, I'm just happy I didn't have to build this from scratch.